### PR TITLE
[ExternalProject] init only selected git submodule

### DIFF
--- a/cmake-next/Modules/ExternalProject.cmake
+++ b/cmake-next/Modules/ExternalProject.cmake
@@ -485,7 +485,7 @@ if(error_code)
 endif()
 
 execute_process(
-  COMMAND \"${git_EXECUTABLE}\" submodule init
+  COMMAND \"${git_EXECUTABLE}\" submodule init ${git_submodules}
   WORKING_DIRECTORY \"${work_dir}/${src_name}\"
   RESULT_VARIABLE error_code
   )


### PR DESCRIPTION
At the moment ExternalProject is initializing all the submodules of a git repository,
even if the user only wants to checkout a subset of submodules . This patch initialize only
the selected submodules, reducing the waiting time for repository with many submodules 
(such as https://github.com/boostorg/boost ).

What is the policy for ExternalProject patches? YCM accept them or they should be submitted upstream?