### PR TITLE
[YCMEPHelper] Fix passing explicit *_COMMAND

### DIFF
--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -994,6 +994,10 @@ function(YCM_EP_HELPER _name)
             if("${ARGN}" MATCHES ";?${_step}_COMMAND;"  AND  NOT DEFINED _YH_${_name}_${_step}_COMMAND)
                 set(_YH_${_name}_${_step}_COMMAND "")
             endif()
+
+            if(DEFINED _YH_${_name}_${_step}_COMMAND)
+                list(APPEND ${_name}_COMMAND_ARGS ${_step}_COMMAND "${_YH_${_name}_${_step}_COMMAND}")
+            endif()
         endif()
     endforeach()
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/robotology/ycm/pull/92?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/ycm/pull/92'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>