### PR TITLE
[IncludeUrl] Don't fail on fs without locks

### DIFF
--- a/modules/IncludeUrl.cmake
+++ b/modules/IncludeUrl.cmake
@@ -237,8 +237,11 @@ macro(INCLUDE_URL _remoteFile)
   # at the time
   # file(LOCK) was added in CMake 3.2, therefore calling it in older version
   # will fail.
+  # The RESULT_VARIABLE parameter is necessary, otherwise IncludeUrl will 
+  # fail on filesystems without lock support
   if(NOT CMAKE_VERSION VERSION_LESS 3.2)
-    file(LOCK "${_lockFile}")
+    file(LOCK "${_lockFile}"
+         RESULT_VARIABLE _IU_LOCK_RESULT)
   endif()
 
   set(_shouldDownload 0)
@@ -371,7 +374,8 @@ macro(INCLUDE_URL _remoteFile)
 
   # Download is finished, we can now release the lock
   if(NOT CMAKE_VERSION VERSION_LESS 3.2)
-    file(LOCK "${_lockFile}" RELEASE)
+    file(LOCK "${_lockFile}" RELEASE
+         RESULT_VARIABLE _IU_LOCK_RELEASE_RESULT)
   endif()
 
   if(NOT EXISTS "${_localFile}" AND NOT _IU_OPTIONAL)


### PR DESCRIPTION
Fix https://github.com/robotology/ycm/issues/93 . 
Without the RESULT_VARIABLE argument, any error of `file(LOCK ...)` is considered fatal.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/robotology/ycm/pull/94%23issuecomment-228434531%22%2C%20%22https%3A//github.com/robotology/ycm/pull/94%23issuecomment-228440743%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/robotology/ycm/pull/94%23issuecomment-228434531%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Wouldn%27t%20this%20make%20completely%20useless%20the%20lock%20itself%3F%5Cr%5CnIf%20A%20locks%20the%20file%20and%20B%20tries%20to%20lock%20it%20but%20fail%20and%20continues%20anyway%20we%20could%20probably%20just%20skip%20the%20lock...%20unless%20cmake%20is%20actually%20locking%20the%20file%20at%20file%20system%20level%2C%20I%20don%27t%20know%20the%20details%20of%20the%20implementation...%22%2C%20%22created_at%22%3A%20%222016-06-24T19%3A08%3A36Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1100056%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/drdanz%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20you%20are%20right..%20for%20some%20reason%20I%20forgot%20that%20the%20failure%20to%20acquire%20the%20lock%20is%20itself%20a%20failure.%20%3A%20%29%20%5Cr%5CnI%20think%20that%20then%20the%20only%20way%20of%20correctly%20implement%20this%20is%20to%20parse%20RESULT_VARIABLE%20and%20only%20fail%20if%20the%20error%20is%20that%20the%20error%20is%20that%20the%20lock%20was%20failed%20to%20acquire.%20If%20instead%20the%20error%20is%20of%20some%20other%20kind%20%28such%20as%20not%20lock%20support%20in%20the%20FS%29%20the%20IncludeUrl%20should%20just%20work%20without%20reporting%20an%20error.%22%2C%20%22created_at%22%3A%20%222016-06-24T19%3A33%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1857049%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/traversaro%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/robotology/ycm/pull/94#issuecomment-228434531'>General Comment</a></b>
- <a href='https://github.com/drdanz'><img border=0 src='https://avatars.githubusercontent.com/u/1100056?v=3' height=16 width=16'></a> Wouldn't this make completely useless the lock itself?
  If A locks the file and B tries to lock it but fail and continues anyway we could probably just skip the lock... unless cmake is actually locking the file at file system level, I don't know the details of the implementation...
- <a href='https://github.com/traversaro'><img border=0 src='https://avatars.githubusercontent.com/u/1857049?v=3' height=16 width=16'></a> Yes, you are right.. for some reason I forgot that the failure to acquire the lock is itself a failure. : )
  I think that then the only way of correctly implement this is to parse RESULT_VARIABLE and only fail if the error is that the error is that the lock was failed to acquire. If instead the error is of some other kind (such as not lock support in the FS) the IncludeUrl should just work without reporting an error.

<a href='https://www.codereviewhub.com/robotology/ycm/pull/94?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/robotology/ycm/pull/94?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/robotology/ycm/pull/94'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
