### PR TITLE
Fix OVITO git repository URL

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -60,7 +60,7 @@ BSD license. See accompanying file COPYING.Eigen for details.
     set(_dir "${CMAKE_CURRENT_BINARY_DIR}/ovito")
 
     _ycm_download(3rdparty-ovito "OVITO (The Open Visualization Tool) git repository"
-                  "https://sourceforge.net/p/ovito/git/ci/<REF>/tree/<FILE>?format=raw"
+                  "https://gitlab.com/stuko/ovito/raw/<REF>/<FILE>"
                   ${_ref} "${_dir}" "${_files}")
 
     file(WRITE "${_dir}/README.OVITO"


### PR DESCRIPTION
Fix https://github.com/robotology/ycm/issues/103

@drdanz Do you want to fix this also for v0.1.* releases ? 