### PR TITLE
Fix InstallBasicPackageFiles preserving compatibility

### DIFF
--- a/help/release/0.2.3.rst
+++ b/help/release/0.2.3.rst
@@ -10,6 +10,13 @@ Changes made since YCM 0.2.2 include the following.
 Modules
 =======
 
+Generic Modules
+---------------
+
+* :module:`InstallBasicPackageFiles`: Fixed an error that was forcing the user
+  to set specific GLOBAL variables to properly export a project. Compatibility
+  is preserved. (#112)
+
 Superbuild Helper Modules
 -------------------------
 

--- a/modules/InstallBasicPackageFiles.cmake
+++ b/modules/InstallBasicPackageFiles.cmake
@@ -69,10 +69,15 @@
 #
 # is defined, the ``<VARS_PREFIX>_<SUFFIX>`` variable will be defined
 # before configuring the package.  In order to use that variable in the
-# config file, a line ou can access to that variable in the config
-# file by using::
+# config file, you have to add a line::
 #
 #   set_and_check(<VARS_PREFIX>_<SUFFIX> \"@PACKAGE_<VARS_PREFIX>_<SUFFIX>@\")
+#
+# if the path must exist or just::
+#
+#   set(<VARS_PREFIX>_<SUFFIX> \"@PACKAGE_<VARS_PREFIX>_<SUFFIX>@\")
+#
+# if the path could be missing.
 #
 # These variable will have different values whether you are using the
 # package from the build tree or from the install directory.  Also these
@@ -278,7 +283,7 @@ function(INSTALL_BASIC_PACKAGE_FILES _Name)
 
 @PACKAGE_INIT@
 
-set_and_check(${_IBPF_VARS_PREFIX}_INCLUDEDIR \"@PACKAGE_${_IBPF_VARS_PREFIX}_INCLUDEDIR@\")
+set(${_IBPF_VARS_PREFIX}_INCLUDEDIR \"@PACKAGE_${_IBPF_VARS_PREFIX}_INCLUDEDIR@\")
 
 if(NOT TARGET ${_target})
   include(\"\${CMAKE_CURRENT_LIST_DIR}/${_targets_filename}\")


### PR DESCRIPTION
There was an error in `InstallBasicPackageFiles.cmake` file which was forcing the user to set in its project cmake file specific GLOBAL variable for properly export the project.

In particular, under specific circumstances, `set_and_check(${_IBPF_VARS_PREFIX}_INCLUDEDIR \"@PACKAGE_${_IBPF_VARS_PREFIX}_INCLUDEDIR@\")` was failing while importing a target using `find_package(<target_name>)`.

This behaviour is fixed [changing set_and_check() with set()](https://github.com/robotology/ycm/compare/master...claudiofantacci:fix/InstallBasicPackageFiles?expand=1#diff-9a0ae61cd4c59dc1be1469c2726733c7L281), thus preserving compatibility.

Furthermore, the file documentation has also been updated.