### PR TITLE
Fix CMake policy CMP0054

### DIFF
--- a/modules/GetAllCMakeProperties.cmake
+++ b/modules/GetAllCMakeProperties.cmake
@@ -24,6 +24,10 @@
 # (To distribute this file outside of YCM, substitute the full
 #  License text for the above reference.)
 
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
+
 function(GET_ALL_CMAKE_PROPERTIES _var)
 
   execute_process(COMMAND ${CMAKE_COMMAND} --help-property-list

--- a/modules/GetAllCMakeProperties.cmake
+++ b/modules/GetAllCMakeProperties.cmake
@@ -24,6 +24,7 @@
 # (To distribute this file outside of YCM, substitute the full
 #  License text for the above reference.)
 
+cmake_policy(PUSH)
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
@@ -62,3 +63,5 @@ function(GET_ALL_CMAKE_PROPERTIES _var)
   set(${_var} ${${_var}} PARENT_SCOPE)
 
 endfunction()
+
+cmake_policy(POP)


### PR DESCRIPTION
This commit, if applied, enforces the new [CMP0054](https://cmake.org/cmake/help/v3.8/policy/CMP0054.html) behavior, if available in the current CMake version.

Fixes #116