### PR TITLE
Ensure that if a package is installed by the superbuild, it is always found by other projects in the superbuild even if it is already found in CMAKE_PREFIX_PATH

### DIFF
--- a/help/release/0.10.0.rst
+++ b/help/release/0.10.0.rst
@@ -44,6 +44,11 @@ Superbuild Helper Modules
   ``SOURCE_SUBDIR``.
 * The :module:`YCMEPHelper` module now passes the variable ``CMAKE_TOOLCHAIN_FILE``
   to the children projects.
+* :module:`YCMEPHelper`: The ``CMAKE_PREFIX_PATH` list passed to the subproject
+  now has the first element the installation directory of the superbuild. This
+  is to ensure that if a package is available in the system but it is disabled
+  using ``USE_SYSTEM_<package>`` set to ``OFF``, the version installed by the
+  superbuild is the one found by the other packages in the superbuild.
 
 
 Find Modules

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -781,7 +781,7 @@ function(YCM_EP_HELPER _name)
   #
   # TODO FIXME check what happens when the "*_COMMAND" arguments are passed.
   file(TO_CMAKE_PATH "$ENV{CMAKE_PREFIX_PATH}" _CMAKE_PREFIX_PATH)
-  list(APPEND _CMAKE_PREFIX_PATH ${${_name}_INSTALL_DIR})
+  list(INSERT _CMAKE_PREFIX_PATH 0 ${${_name}_INSTALL_DIR})
   list(REMOVE_DUPLICATES _CMAKE_PREFIX_PATH)
   string(REPLACE ";" "|" _CMAKE_PREFIX_PATH "${_CMAKE_PREFIX_PATH}")
   set(${_name}_ALL_CMAKE_ARGS LIST_SEPARATOR "|")


### PR DESCRIPTION
Rationale: if I have a superbuild in which I set `USE_SYSTEM_YARP` to `OFF`, I want that all the other projects built by the superbuild find the `YARP` package installed by the superbuild, not the one that may be found in other variables defined in the `CMAKE_PREFIX_PATH` env variable. 


Note: to be honest I do not fully understand the code: 
~~~
  # ExternalProject does not handle correctly arguments containing ";" passed
  # using CMAKE_ARGS, and instead splits them into several arguments. This is
  # a workaround that replaces ";" with "|" and sets LIST_SEPARATOR "|" in
  # order to interpret them correctly.
  #
  # TODO FIXME check what happens when the "*_COMMAND" arguments are passed.
  file(TO_CMAKE_PATH "$ENV{CMAKE_PREFIX_PATH}" _CMAKE_PREFIX_PATH)
  list(APPEND _CMAKE_PREFIX_PATH ${${_name}_INSTALL_DIR})
  list(REMOVE_DUPLICATES _CMAKE_PREFIX_PATH)
  string(REPLACE ";" "|" _CMAKE_PREFIX_PATH "${_CMAKE_PREFIX_PATH}")
set(${_name}_ALL_CMAKE_ARGS LIST_SEPARATOR "|")
~~~
Why the `CMAKE_PREFIX_PATH` environmental variable is transformed in the CMAKE_PREFIX_PATH passed as a option to the subproject? If that was not the case, this patch would not be needed. However, I opted for minimal number of changes, just by changing the line:
~~~
  list(APPEND _CMAKE_PREFIX_PATH ${${_name}_INSTALL_DIR})
~~~
to
~~~
  list(INSERT _CMAKE_PREFIX_PATH 0 ${${_name}_INSTALL_DIR})
~~~