### PR TITLE
Introduce YCM_MINIMUM_VERSION input in YCMBootrap

### DIFF
--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -86,7 +86,7 @@ set(_ycm_ExternalProject_sha1sum     54a1031a8f1e6a7462072ea5c3d24f68567ab4ad)
 
 # Files in all projects that need to bootstrap YCM
 set(_ycm_IncludeUrl_sha1sum          ccb03a4975faccabc9032cada2624ccfda42d238)
-set(_ycm_YCMBootstrap_sha1sum        cfa7120cdbe8e6c532469b66221efe2120a54bc8)
+set(_ycm_YCMBootstrap_sha1sum        dd95e1d38e045091e2e6c1ba2a96d540f1b8af0d)
 
 
 ########################################################################

--- a/tools/YCMBootstrap.cmake
+++ b/tools/YCMBootstrap.cmake
@@ -19,6 +19,13 @@
 # The real bootstrap is performed by the ycm_bootstrap macro from the
 # YCMEPHelper module that is downloaded from the YCM package.
 
+# CMake variables read as input by this module:
+# YCM_MINIMUM_VERSION : minimum version of YCM requested to use a system YCM 
+# YCM_TAG     : if no suitable system YCM was found, bootstrap from this 
+#             : TAG (either branch, commit or tag) of YCM repository 
+# USE_SYSTEM_YCM : if defined and set FALSE, skip searching for a system 
+#                  YCM and always bootstrap
+
 
 if(DEFINED __YCMBOOTSTRAP_INCLUDED)
   return()
@@ -71,7 +78,7 @@ _ycm_clean_path("${CMAKE_BINARY_DIR}/install" PATH)
 
 # If the USE_SYSTEM_YCM is explicitly set to false, we just skip to bootstrap.
 if(NOT DEFINED USE_SYSTEM_YCM OR USE_SYSTEM_YCM)
-    find_package(YCM QUIET)
+    find_package(YCM ${YCM_MINIMUM_VERSION} QUIET)
     if(COMMAND set_package_properties)
         set_package_properties(YCM PROPERTIES TYPE RECOMMENDED
                                               PURPOSE "Used by the build system")


### PR DESCRIPTION
This variable specifies an option version requested when searching for a system YCM package.
This solves https://github.com/robotology/robotology-superbuild/issues/21 .
Furthermore, add some documentation about the CMake variable read in input by this script.