### PR TITLE
Add CMake 3.9+ stuff to module path on YCM load

### DIFF
--- a/YCMConfig.cmake.in
+++ b/YCMConfig.cmake.in
@@ -56,12 +56,7 @@ foreach(_version 3.11
                  3.9
                  3.8
                  3.7
-                 3.6
-                 3.5
-                 3.4
-                 3.3
-                 3.2
-                 3.1)
+                 3.6)
   if(EXISTS "${YCM_MODULE_DIR}/cmake-${_version}"
      AND CMAKE_MINIMUM_REQUIRED_VERSION VERSION_LESS ${_version}
      AND CMAKE_VERSION VERSION_LESS ${_version})

--- a/YCMConfig.cmake.in
+++ b/YCMConfig.cmake.in
@@ -51,7 +51,10 @@ if(YCM_USE_CMAKE_NEXT)
     list(APPEND YCM_MODULE_PATH "${YCM_MODULE_DIR}/cmake-next/Modules")
 endif()
 
-foreach(_version 3.8
+foreach(_version 3.11
+                 3.10
+                 3.9
+                 3.8
                  3.7
                  3.6
                  3.5

--- a/cmake-next/CMakeLists.txt
+++ b/cmake-next/CMakeLists.txt
@@ -92,7 +92,7 @@ endfunction()
 
 
 # Downloaded modules               CMake Version   Uncommitted
-#                                  Version         Changes
+#                                                  Changes
 #
 #  FindMatlab                       3.7
 #  FeatureSummary                   3.8
@@ -108,6 +108,8 @@ endfunction()
 # Changes in dependencies
 #  FindPackageHandleStandardArgs
 
+# NOTE: keep CMake version values listed at root/YCMConfig.cmake.in up
+# to date with changes in the previous table.
 
 
 ################################################################################


### PR DESCRIPTION
Just a follow-up to #139 so that downstreams can actually use these modules. The only relevant value here is `3.11` per [cmake-next/CMakeLists.txt](https://github.com/robotology/ycm/blob/5503af083d2719f4bda1ddfe979ffad8ea3fd66b/cmake-next/CMakeLists.txt).