### PR TITLE
Fix typo, actually compare first argument to known find_package options

### DIFF
--- a/help/release/0.9.1.rst
+++ b/help/release/0.9.1.rst
@@ -6,3 +6,12 @@ YCM 0.9.1 (UNRELEASED) Release Notes
   .. contents::
 
 Changes made since YCM 0.9.0 include the following.
+
+Modules
+=======
+
+Generic Modules
+---------------
+
+* :module:`FindOrBuildPackage`: Fixed a typo that made ``find_or_build_package``
+  dismiss the first argument passed after the requested package name.

--- a/modules/FindOrBuildPackage.cmake
+++ b/modules/FindOrBuildPackage.cmake
@@ -116,7 +116,7 @@ function(FIND_OR_BUILD_PACKAGE _pkg)
                         CMAKE_FIND_ROOT_PATH_BOTH
                         ONLY_CMAKE_FIND_ROOT_PATH
                         NO_CMAKE_FIND_ROOT_PATH)
-            if("${_version}" STREQUAL "${arg}")
+            if("${_version}" STREQUAL "${_arg}")
                 unset(_version)
                 break()
             endif()


### PR DESCRIPTION
The typo is obvious. I came across this when configuring a project with `find_or_build_package(MyPackage CONFIG)`. The error message stated:

```
CMake Error at /usr/local/share/YCM/modules/FindOrBuildPackage.cmake:175 (find_package):
  find_package given options exclusive to Module mode:

    MODULE

  and options exclusive to Config mode:

    CONFIG

  The options are incompatible.
Call Stack (most recent call first):
  CMakeLists.txt:5 (find_or_build_package)


-- Configuring incomplete, errors occurred!
```
It originated at:

https://github.com/robotology/ycm/blob/4620eeead4f7f855cf2b0f1565a89f93e3e427c5/modules/FindOrBuildPackage.cmake#L172-L176

In fact, `_${_PKG}_CONFIG` is empty at this point, because `${ARGN}` was empty here:

https://github.com/robotology/ycm/blob/4620eeead4f7f855cf2b0f1565a89f93e3e427c5/modules/FindOrBuildPackage.cmake#L144

...because a previous instruction erased its value:

https://github.com/robotology/ycm/blob/4620eeead4f7f855cf2b0f1565a89f93e3e427c5/modules/FindOrBuildPackage.cmake#L124-L126

...because of that typo:

https://github.com/robotology/ycm/blob/4620eeead4f7f855cf2b0f1565a89f93e3e427c5/modules/FindOrBuildPackage.cmake#L119-L122

...since it should be `_arg`:

https://github.com/robotology/ycm/blob/4620eeead4f7f855cf2b0f1565a89f93e3e427c5/modules/FindOrBuildPackage.cmake#L94