### PR TITLE
Comment on fix of FindESDCANAPI module added

### DIFF
--- a/help/release/0.9.1.rst
+++ b/help/release/0.9.1.rst
@@ -22,3 +22,4 @@ Find Modules
 * The :module:`FindGLFW3` is now using the ``glfw`` target exported from upstream
   if available.
 
+* The :module:`FindESDCANAPI` is now also compatible with 64 bit libraries.


### PR DESCRIPTION
Comment related to the pull request #180 about the fix of the compatibility of FindESDCANAPI.cmake with 64 bit libraries added.