### PR TITLE
ExternalProject sync

### DIFF
--- a/cmake-next/proposed/ExternalProject-download.cmake.in
+++ b/cmake-next/proposed/ExternalProject-download.cmake.in
@@ -1,0 +1,162 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+cmake_minimum_required(VERSION 3.5)
+
+function(check_file_hash has_hash hash_is_good)
+  if("${has_hash}" STREQUAL "")
+    message(FATAL_ERROR "has_hash Can't be empty")
+  endif()
+
+  if("${hash_is_good}" STREQUAL "")
+    message(FATAL_ERROR "hash_is_good Can't be empty")
+  endif()
+
+  if("@ALGO@" STREQUAL "")
+    # No check
+    set("${has_hash}" FALSE PARENT_SCOPE)
+    set("${hash_is_good}" FALSE PARENT_SCOPE)
+    return()
+  endif()
+
+  set("${has_hash}" TRUE PARENT_SCOPE)
+
+  message(STATUS "verifying file...
+       file='@LOCAL@'")
+
+  file("@ALGO@" "@LOCAL@" actual_value)
+
+  if(NOT "${actual_value}" STREQUAL "@EXPECT_VALUE@")
+    set("${hash_is_good}" FALSE PARENT_SCOPE)
+    message(STATUS "@ALGO@ hash of
+    @LOCAL@
+  does not match expected value
+    expected: '@EXPECT_VALUE@'
+      actual: '${actual_value}'")
+  else()
+    set("${hash_is_good}" TRUE PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(sleep_before_download attempt)
+  if(attempt EQUAL 0)
+    return()
+  endif()
+
+  if(attempt EQUAL 1)
+    message(STATUS "Retrying...")
+    return()
+  endif()
+
+  set(sleep_seconds 0)
+
+  if(attempt EQUAL 2)
+    set(sleep_seconds 5)
+  elseif(attempt EQUAL 3)
+    set(sleep_seconds 5)
+  elseif(attempt EQUAL 4)
+    set(sleep_seconds 15)
+  elseif(attempt EQUAL 5)
+    set(sleep_seconds 60)
+  elseif(attempt EQUAL 6)
+    set(sleep_seconds 90)
+  elseif(attempt EQUAL 7)
+    set(sleep_seconds 300)
+  else()
+    set(sleep_seconds 1200)
+  endif()
+
+  message(STATUS "Retry after ${sleep_seconds} seconds (attempt #${attempt}) ...")
+
+  execute_process(COMMAND "${CMAKE_COMMAND}" -E sleep "${sleep_seconds}")
+endfunction()
+
+if("@LOCAL@" STREQUAL "")
+  message(FATAL_ERROR "LOCAL can't be empty")
+endif()
+
+if("@REMOTE@" STREQUAL "")
+  message(FATAL_ERROR "REMOTE can't be empty")
+endif()
+
+if(EXISTS "@LOCAL@")
+  check_file_hash(has_hash hash_is_good)
+  if(has_hash)
+    if(hash_is_good)
+      message(STATUS "File already exists and hash match (skip download):
+  file='@LOCAL@'
+  @ALGO@='@EXPECT_VALUE@'"
+      )
+      return()
+    else()
+      message(STATUS "File already exists but hash mismatch. Removing...")
+      file(REMOVE "@LOCAL@")
+    endif()
+  else()
+    message(STATUS "File already exists but no hash specified (use URL_HASH):
+  file='@LOCAL@'
+Old file will be removed and new file downloaded from URL."
+    )
+    file(REMOVE "@LOCAL@")
+  endif()
+endif()
+
+set(retry_number 5)
+
+message(STATUS "Downloading...
+   dst='@LOCAL@'
+   timeout='@TIMEOUT_MSG@'"
+)
+
+foreach(i RANGE ${retry_number})
+  sleep_before_download(${i})
+
+  foreach(url @REMOTE@)
+    message(STATUS "Using src='${url}'")
+
+    @TLS_VERIFY_CODE@
+    @TLS_CAINFO_CODE@
+    @NETRC_CODE@
+    @NETRC_FILE_CODE@
+
+    file(
+        DOWNLOAD
+        "${url}" "@LOCAL@"
+        @SHOW_PROGRESS@
+        @TIMEOUT_ARGS@
+        STATUS status
+        LOG log
+        @USERPWD_ARGS@
+        @HTTP_HEADERS_ARGS@
+    )
+
+    list(GET status 0 status_code)
+    list(GET status 1 status_string)
+
+    if(status_code EQUAL 0)
+      check_file_hash(has_hash hash_is_good)
+      if(has_hash AND NOT hash_is_good)
+        message(STATUS "Hash mismatch, removing...")
+        file(REMOVE "@LOCAL@")
+      else()
+        message(STATUS "Downloading... done")
+        return()
+      endif()
+    else()
+      string(APPEND logFailedURLs "error: downloading '${url}' failed
+       status_code: ${status_code}
+       status_string: ${status_string}
+       log:
+       --- LOG BEGIN ---
+       ${log}
+       --- LOG END ---
+       "
+      )
+    endif()
+  endforeach()
+endforeach()
+
+message(FATAL_ERROR "Each download failed!
+  ${logFailedURLs}
+  "
+)

--- a/cmake-next/proposed/ExternalProject-verify.cmake.in
+++ b/cmake-next/proposed/ExternalProject-verify.cmake.in
@@ -1,0 +1,37 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+cmake_minimum_required(VERSION 3.5)
+
+if("@LOCAL@" STREQUAL "")
+  message(FATAL_ERROR "LOCAL can't be empty")
+endif()
+
+if(NOT EXISTS "@LOCAL@")
+  message(FATAL_ERROR "File not found: @LOCAL@")
+endif()
+
+if("@ALGO@" STREQUAL "")
+  message(WARNING "File will not be verified since no URL_HASH specified")
+  return()
+endif()
+
+if("@EXPECT_VALUE@" STREQUAL "")
+  message(FATAL_ERROR "EXPECT_VALUE can't be empty")
+endif()
+
+message(STATUS "verifying file...
+     file='@LOCAL@'")
+
+file("@ALGO@" "@LOCAL@" actual_value)
+
+if(NOT "${actual_value}" STREQUAL "@EXPECT_VALUE@")
+  message(FATAL_ERROR "error: @ALGO@ hash of
+  @LOCAL@
+does not match expected value
+  expected: '@EXPECT_VALUE@'
+    actual: '${actual_value}'
+")
+endif()
+
+message(STATUS "verifying file... done")

--- a/cmake-next/proposed/ExternalProject.cmake
+++ b/cmake-next/proposed/ExternalProject.cmake
@@ -1041,6 +1041,13 @@ define_property(DIRECTORY PROPERTY "EP_UPDATE_DISCONNECTED" INHERITED
   "ExternalProject module."
   )
 
+define_property(DIRECTORY PROPERTY "EP_SOURCE_DIR_PERSISTENT" INHERITED
+  BRIEF_DOCS "Whether source dir stored outside the build directory should be preserved."
+  FULL_DOCS
+  "See documentation of the ExternalProject_Add() function in the "
+  "ExternalProject module."
+  )
+
 function(_ep_write_gitclone_script script_filename source_dir git_EXECUTABLE git_repository git_tag git_remote_name git_submodules git_shallow git_progress git_config src_name work_dir gitclone_infofile gitclone_stampfile tls_verify)
   if(NOT GIT_VERSION_STRING VERSION_LESS 1.7.10)
     set(git_clone_shallow_options "--depth 1 --no-single-branch")
@@ -1072,14 +1079,6 @@ if(NOT run)
   return()
 endif()
 
-execute_process(
-  COMMAND \${CMAKE_COMMAND} -E remove_directory \"${source_dir}\"
-  RESULT_VARIABLE error_code
-  )
-if(error_code)
-  message(FATAL_ERROR \"Failed to remove directory: '${source_dir}'\")
-endif()
-
 set(git_options)
 
 # disable cert checking if explicitly told not to do it
@@ -1106,23 +1105,94 @@ foreach(config IN LISTS git_config)
   list(APPEND git_clone_options --config \${config})
 endforeach()
 
-# try the clone 3 times in case there is an odd git clone issue
-set(error_code 1)
-set(number_of_tries 0)
-while(error_code AND number_of_tries LESS 3)
-  execute_process(
-    COMMAND \"${git_EXECUTABLE}\" \${git_options} clone \${git_clone_options} --origin \"${git_remote_name}\" \"${git_repository}\" \"${src_name}\"
-    WORKING_DIRECTORY \"${work_dir}\"
-    RESULT_VARIABLE error_code
-    )
-  math(EXPR number_of_tries \"\${number_of_tries} + 1\")
-endwhile()
-if(number_of_tries GREATER 1)
-  message(STATUS \"Had to git clone more than once:
-          \${number_of_tries} times.\")
+if(EXISTS \"${source_dir}\" AND ${source_dir_persistent})
+  if(NOT IS_DIRECTORY \"${source_dir}\")
+    # FIXME Perhaps support symbolic links?
+    message(FATAL_ERROR \"\\\"${source_dir}\\\" exists and is not a git repository. Remove it and try again\")
+  elseif(NOT IS_DIRECTORY \"${source_dir}/.git\")
+    file(GLOB files \"${source_dir}/*\")
+    list(LENGTH files nfiles)
+    if(nfiles)
+      message(FATAL_ERROR \"\\\"${source_dir}\\\" folder exists and is not a git repository. Remove it and try again\")
+    endif()
+  else()
+    # Already initialized git repository: no need to clone again
+    execute_process(
+      COMMAND \"${git_EXECUTABLE}\" config --local --get remote.origin.url
+      WORKING_DIRECTORY \"${work_dir}/${src_name}\"
+      OUTPUT_VARIABLE origin_url
+      RESULT_VARIABLE error_code
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+    if(error_code)
+      message(FATAL_ERROR \"Failed to get origin remote url in: '${work_dir}/${src_name}'\")
+    endif()
+    if(\"\${origin_url}\" STREQUAL \"${git_repository}\")
+      message(STATUS \"Avoiding repeated git clone, repository already exists\")
+      return()
+    else()
+      string(TIMESTAMP now \"%Y%m%d%H%M%S\")
+      message(WARNING \"Repository URL is different. Renaming origin remote to origin.\${now}\")
+      execute_process(
+        COMMAND \"${git_EXECUTABLE}\" remote rename origin origin.\${now}
+        WORKING_DIRECTORY \"${work_dir}/${src_name}\"
+        RESULT_VARIABLE error_code
+        )
+      if(error_code)
+        message(FATAL_ERROR \"Failed to rename remote in: '${work_dir}/${src_name}'\")
+      endif()
+
+      execute_process(
+        COMMAND \"${git_EXECUTABLE}\" remote add origin \"${git_repository}\"
+        WORKING_DIRECTORY \"${work_dir}/${src_name}\"
+        RESULT_VARIABLE error_code
+        )
+      if(error_code)
+        message(FATAL_ERROR \"Failed to add origin remote in: '${work_dir}/${src_name}'\")
+      endif()
+
+      # try the fetch 3 times incase there is an odd git fetch issue
+      set(error_code 1)
+      set(number_of_tries 0)
+      while(error_code AND number_of_tries LESS 3)
+        execute_process(
+          COMMAND \"${git_EXECUTABLE}\" \${git_options} fetch \${git_clone_options} origin
+          WORKING_DIRECTORY \"${work_dir}/${src_name}\"
+          RESULT_VARIABLE error_code
+          )
+        math(EXPR number_of_tries \"\${number_of_tries} + 1\")
+      endwhile()
+      if(number_of_tries GREATER 1)
+        message(STATUS \"Had to git fetch more than once:
+                \${number_of_tries} times.\")
+      endif()
+      if(error_code)
+        message(FATAL_ERROR \"Failed to fetch in: '${work_dir}/${src_name}'\")
+      endif()
+    endif()
+  endif()
 endif()
-if(error_code)
-  message(FATAL_ERROR \"Failed to clone repository: '${git_repository}'\")
+
+# Now perform the clone if still required
+if(NOT IS_DIRECTORY \"${source_dir}/.git\")
+  # try the clone 3 times incase there is an odd git clone issue
+  set(error_code 1)
+  set(number_of_tries 0)
+  while(error_code AND number_of_tries LESS 3)
+    execute_process(
+    COMMAND \"${git_EXECUTABLE}\" \${git_options} clone \${git_clone_options} --origin \"${git_remote_name}\" \"${git_repository}\" \"${src_name}\"
+      WORKING_DIRECTORY \"${work_dir}\"
+      RESULT_VARIABLE error_code
+      )
+    math(EXPR number_of_tries \"\${number_of_tries} + 1\")
+  endwhile()
+  if(number_of_tries GREATER 1)
+    message(STATUS \"Had to git clone more than once:
+            \${number_of_tries} times.\")
+  endif()
+  if(error_code)
+    message(FATAL_ERROR \"Failed to clone repository: '${git_repository}'\")
+  endif()
 endif()
 
 execute_process(

--- a/cmake-next/proposed/ExternalProject.cmake
+++ b/cmake-next/proposed/ExternalProject.cmake
@@ -1041,13 +1041,6 @@ define_property(DIRECTORY PROPERTY "EP_UPDATE_DISCONNECTED" INHERITED
   "ExternalProject module."
   )
 
-define_property(DIRECTORY PROPERTY "EP_SOURCE_DIR_PERSISTENT" INHERITED
-  BRIEF_DOCS "Whether source dir stored outside the build directory should be preserved."
-  FULL_DOCS
-  "See documentation of the ExternalProject_Add() function in the "
-  "ExternalProject module."
-  )
-
 function(_ep_write_gitclone_script script_filename source_dir git_EXECUTABLE git_repository git_tag git_remote_name git_submodules git_shallow git_progress git_config src_name work_dir gitclone_infofile gitclone_stampfile tls_verify)
   if(NOT GIT_VERSION_STRING VERSION_LESS 1.7.10)
     set(git_clone_shallow_options "--depth 1 --no-single-branch")
@@ -1105,7 +1098,7 @@ foreach(config IN LISTS git_config)
   list(APPEND git_clone_options --config \${config})
 endforeach()
 
-if(EXISTS \"${source_dir}\" AND ${source_dir_persistent})
+if(EXISTS \"${source_dir}\")
   if(NOT IS_DIRECTORY \"${source_dir}\")
     # FIXME Perhaps support symbolic links?
     message(FATAL_ERROR \"\\\"${source_dir}\\\" exists and is not a git repository. Remove it and try again\")

--- a/help/release/0.10.0.rst
+++ b/help/release/0.10.0.rst
@@ -15,7 +15,15 @@ Generic Modules
 ---------------
 
 * The :module:`InstallBasicPackageFiles` module learned to forward the
-  ``ARCH_INDEPENDENT`` option to :command:`write_basic_package_version_file`
+  ``ARCH_INDEPENDENT`` option to :command:`write_basic_package_version_file`.
+* The :module:`IncludeUrl` module now always perform the lock/unlock.
+
+Superbuild Helper Modules
+-------------------------
+
+* The :module:`YCMEPHelper` module now supports the ``CMAKE_CACHE_DEFAULT_ARGS``
+  argument.
+
 
 Find Modules
 ------------
@@ -33,6 +41,9 @@ CMake Next
   :command:`write_basic_package_version_file`.
 * Imported :module:`FetchContent` module from CMake 3.11.
 * Imported :module:`FindOpenGL` module from CMake 3.10.
+* The :module:`ExternalProject` module was updated from CMake master.
+  All the customizations were removed, with the exception of the ``git``
+  deleting clones fix.
 
 
 3rd Party

--- a/modules/IncludeUrl.cmake
+++ b/modules/IncludeUrl.cmake
@@ -235,11 +235,7 @@ macro(INCLUDE_URL _remoteFile)
 
   # Lock the file, in case 2 different processes are downloading the same file
   # at the time
-  # file(LOCK) was added in CMake 3.2, therefore calling it in older version
-  # will fail.
-  if(NOT CMAKE_VERSION VERSION_LESS 3.2)
-    file(LOCK "${_lockFile}")
-  endif()
+  file(LOCK "${_lockFile}")
 
   set(_shouldDownload 0)
   set(_shouldFail 0)
@@ -370,9 +366,7 @@ macro(INCLUDE_URL _remoteFile)
   endif()
 
   # Download is finished, we can now release the lock
-  if(NOT CMAKE_VERSION VERSION_LESS 3.2)
-    file(LOCK "${_lockFile}" RELEASE)
-  endif()
+  file(LOCK "${_lockFile}" RELEASE)
 
   if(NOT EXISTS "${_localFile}" AND NOT _IU_OPTIONAL)
     message(FATAL_ERROR "Downloaded file does not exist. Please report this as a bug")

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -821,11 +821,7 @@ function(YCM_EP_HELPER _name)
   endif()
 
   # CMAKE_CACHE_DEFAULT_ARGS (Initial cache, default)
-  if(DEFINED ${_name}_YCM_CMAKE_CACHE_DEFAULT_ARGS)
-    # FIXME Do not add the "CMAKE_CACHE_DEFAULT_ARGS" until the ExternalProject module
-    # is updated from CMake
-    set(${_name}_CMAKE_CACHE_DEFAULT_ARGS ${${_name}_YCM_CMAKE_CACHE_DEFAULT_ARGS})
-  endif()
+  set(${_name}_CMAKE_CACHE_DEFAULT_ARGS CMAKE_CACHE_DEFAULT_ARGS ${${_name}_YCM_CMAKE_CACHE_DEFAULT_ARGS})
   if(_YH_${_name}_CMAKE_CACHE_DEFAULT_ARGS)
     list(APPEND ${_name}_CMAKE_CACHE_DEFAULT_ARGS ${_YH_${_name}_CMAKE_CACHE_DEFAULT_ARGS})
   endif()

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -82,10 +82,10 @@ set(__YCMEPHELPER_INCLUDED TRUE)
 
 # Files downloaded during YCM bootstrap
 set(_ycm_CMakeParseArguments_sha1sum 0c4d3f7ed248145cbeb67cbd6fd7190baf2e4517)
-set(_ycm_ExternalProject_sha1sum     198329b8d7128ba5feaf1280f178a2befde1506b)
+set(_ycm_ExternalProject_sha1sum     fe14746d2eb6b6e5179c61c9a669a535ca60e1ca)
 
 # Files in all projects that need to bootstrap YCM
-set(_ycm_IncludeUrl_sha1sum          ccb03a4975faccabc9032cada2624ccfda42d238)
+set(_ycm_IncludeUrl_sha1sum          921a037133255d01b644c16f19494cb08d98c462)
 set(_ycm_YCMBootstrap_sha1sum        dd95e1d38e045091e2e6c1ba2a96d540f1b8af0d)
 
 
@@ -192,10 +192,9 @@ macro(_YCM_SETUP)
   _ycm_include(CMakeParseArguments)
   _ycm_include(ExternalProject)
 
-  set_property(DIRECTORY PROPERTY EP_SOURCE_DIR_PERSISTENT 1)
   if(NOT NON_INTERACTIVE_BUILD)
     # Non interactive builds should always perform the update step
-    set_property(DIRECTORY PROPERTY EP_SCM_DISCONNECTED 1)
+    set_property(DIRECTORY PROPERTY EP_UPDATE_DISCONNECTED 1)
   endif()
   set_property(DIRECTORY PROPERTY CMAKE_PARSE_ARGUMENTS_DEFAULT_SKIP_EMPTY FALSE)
   set_property(GLOBAL PROPERTY USE_FOLDERS ON)


### PR DESCRIPTION
Update `ExternalProject` from CMake `master` and apply the patch to avoid deleting the clones.

TODO: 
- [x] Proper testing on actual superbuilds
- [ ] Test shallow clones
- [ ] (optional, but recommended) Propose the change upstream.

CC: @traversaro