### PR TITLE
Pass CMAKE_TOOLCHAIN_FILE variable to subprojects

### DIFF
--- a/help/release/0.10.0.rst
+++ b/help/release/0.10.0.rst
@@ -26,6 +26,8 @@ Superbuild Helper Modules
 * The :module:`YCMEPHelper` module supports the ``SOURCE_SUBDIR`` argument.
   The ``CONFIGURE_SOURCE_DIR`` argument is now deprecated in favour of
   ``SOURCE_SUBDIR``.
+* The :module:`YCMEPHelper` module now passes the variable ``CMAKE_TOOLCHAIN_FILE``
+  to the children projects.
 
 
 Find Modules

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -794,6 +794,10 @@ function(YCM_EP_HELPER _name)
   # Default CMAKE_CACHE_ARGS (Initial cache, forced)
   set(${_name}_YCM_CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:PATH=${${_name}_INSTALL_DIR}") # Where to do the installation
 
+  if(DEFINED CMAKE_TOOLCHAIN_FILE)
+    list(APPEND ${_name}_YCM_CMAKE_CACHE_ARGS "-DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}")
+  endif()
+
   # Default CMAKE_CACHE_DEFAULT_ARGS (Initial cache, default)
   unset(${_name}_YCM_CMAKE_CACHE_DEFAULT_ARGS)
   if(NOT CMAKE_BUILD_TYPE STREQUAL "") # CMAKE_BUILD_TYPE is always defined


### PR DESCRIPTION
When creating a super-build, the variable CMAKE_TOOLCHAIN_FILE should be passed along to the subprojects. A more detailed discussion can be found on #129.
The implemented solution is the one proposed by @traversaro here https://github.com/robotology/ycm/issues/129#issuecomment-400388086, and was tested in the context of compiling gazebo for Windows using vcpkg.