### PR TITLE
[WIP] Update FindGLEW to replicate upstream behaviour

### DIFF
--- a/cmake-next/proposed/FindGLEW.cmake
+++ b/cmake-next/proposed/FindGLEW.cmake
@@ -56,6 +56,8 @@ This module defines the following variables:
 
 find_package(GLEW CONFIG QUIET)
 
+include(FindPackageHandleStandardArgs)
+
 if(GLEW_FOUND)
   find_package_handle_standard_args(GLEW DEFAULT_MSG GLEW_CONFIG)
   return()
@@ -176,7 +178,6 @@ if(GLEW_VERBOSE)
   message(STATUS "FindGLEW: GLEW_VERSION: ${GLEW_VERSION}")
 endif()
 
-include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GLEW
                                   REQUIRED_VARS GLEW_INCLUDE_DIRS GLEW_LIBRARIES
                                   VERSION_VAR GLEW_VERSION)

--- a/cmake-next/proposed/FindGLEW.cmake
+++ b/cmake-next/proposed/FindGLEW.cmake
@@ -1,72 +1,300 @@
-#.rst:
-# FindGLEW
-# --------
-#
-# Find the OpenGL Extension Wrangler Library (GLEW)
-#
-# IMPORTED Targets
-# ^^^^^^^^^^^^^^^^
-#
-# This module defines the :prop_tgt:`IMPORTED` target ``GLEW::GLEW``,
-# if GLEW has been found.
-#
-# Result Variables
-# ^^^^^^^^^^^^^^^^
-#
-# This module defines the following variables:
-#
-# ::
-#
-#   GLEW_INCLUDE_DIRS - include directories for GLEW
-#   GLEW_LIBRARIES - libraries to link against GLEW
-#   GLEW_FOUND - true if GLEW has been found and can be used
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
 
-#=============================================================================
-# Copyright 2012 Benjamin Eikel
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+#[=======================================================================[.rst:
+FindGLEW
+--------
+
+Find the OpenGL Extension Wrangler Library (GLEW)
+
+Input variables
+^^^^^^^^^^^^^^^
+
+The following variables may be set to influence this module’s behavior:
+
+``GLEW_USE_STATIC_LIBS``
+  to find and create :prop_tgt:`IMPORTED` target for static linkage.
+
+``GLEW_VERBOSE``
+  to output a detailed log of this module.
+
+Imported targets
+^^^^^^^^^^^^^^^^
+
+This module defines the :prop_tgt:`IMPORTED` target ``GLEW::glew`` for the
+shared library GLEW. If ``GLEW_USE_STATIC_LIBS`` is defined and set to ``TRUE``,
+this module instad defines the :prop_tgt:`IMPORTED` target ``GLEW::glew_s`` for
+the static library GLEW.
+Further, an :prop_tgt:`IMPORTED` target ``GLEW::GLEW`` is created as a copy of
+either ``GLEW::glew`` or ``GLEW::glew_s``.
+
+Result variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``GLEW_INCLUDE_DIRS``
+  include directories for GLEW
+``GLEW_LIBRARIES``
+  libraries to link against GLEW
+``GLEW_SHARED_LIBRARIES``
+  libraries to link against shared GLEW
+``GLEW_STATIC_LIBRARIES``
+  libraries to link against static GLEW
+``GLEW_FOUND``
+  true if GLEW has been found and can be used
+``GLEW_VERSION``
+  GLEW version
+``GLEW_VERSION_MAJOR``
+  GLEW major version
+``GLEW_VERSION_MINOR``
+  GLEW minor version
+``GLEW_VERSION_MICRO``
+  GLEW micro version
+
+#]=======================================================================]
+
+find_package(GLEW CONFIG QUIET)
+
+if(GLEW_FOUND)
+  find_package_handle_standard_args(GLEW DEFAULT_MSG GLEW_CONFIG)
+  return()
+endif()
+
+if(GLEW_VERBOSE)
+  message(STATUS "FindGLEW: did not find GLEW CMake config file. Searching for libraries.")
+endif()
 
 
-if(${CMAKE_GENERATOR_PLATFORM} MATCHES "x64" OR "${CMAKE_GENERATOR}" MATCHES "Win64")
+function(set_find_library_suffix shared_or_static)
+  if(UNIX AND "${shared_or_static}" MATCHES "SHARED")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".so" PARENT_SCOPE)
+  elseif(UNIX AND "${shared_or_static}" MATCHES "STATIC")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" PARENT_SCOPE)
+  elseif(APPLE AND "${shared_or_static}" MATCHES "SHARED")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".dylib;.so" PARENT_SCOPE)
+  elseif(APPLE AND "${shared_or_static}" MATCHES "STATIC")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".a" PARENT_SCOPE)
+  elseif(WIN32 AND "${shared_or_static}" MATCHES "SHARED")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" PARENT_SCOPE)
+  elseif(WIN32 AND "${shared_or_static}" MATCHES "STATIC")
+    set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib;.dll.a" PARENT_SCOPE)
+  endif()
+
+  if(GLEW_VERBOSE)
+    message(STATUS "FindGLEW: CMAKE_FIND_LIBRARY_SUFFIXES for ${shared_or_static}: ${CMAKE_FIND_LIBRARY_SUFFIXES}")
+  endif()
+endfunction()
+
+
+if(GLEW_VERBOSE)
+  if(DEFINED GLEW_USE_STATIC_LIBS)
+    message(STATUS "FindGLEW: GLEW_USE_STATIC_LIBS: ${GLEW_USE_STATIC_LIBS}.")
+  else()
+    message(STATUS "FindGLEW: GLEW_USE_STATIC_LIBS is undefined. Treated as FALSE.")
+  endif()
+endif()
+
+find_path(GLEW_INCLUDE_DIR GL/glew.h)
+mark_as_advanced(GLEW_INCLUDE_DIR)
+
+set(GLEW_INCLUDE_DIRS ${GLEW_INCLUDE_DIR})
+
+if(GLEW_VERBOSE)
+  message(STATUS "FindGLEW: GLEW_INCLUDE_DIR: ${GLEW_INCLUDE_DIR}")
+  message(STATUS "FindGLEW: GLEW_INCLUDE_DIRS: ${GLEW_INCLUDE_DIRS}")
+endif()
+
+if("${CMAKE_GENERATOR_PLATFORM}" MATCHES "x64" OR "${CMAKE_GENERATOR}" MATCHES "Win64")
   set(_arch "x64")
 else()
   set(_arch "Win32")
 endif()
 
-find_path(GLEW_INCLUDE_DIR
-          NAMES GL/glew.h
-          PATH_SUFFIXES include
-          PATHS ENV GLEW_ROOT)
-find_library(GLEW_LIBRARY
-             NAMES GLEW
-                   glew32
-                   glew
-                   glew32s
-             PATH_SUFFIXES lib
-                           lib64
-                           lib/Release/${_arch}
+
+set_find_library_suffix(SHARED)
+
+find_library(GLEW_SHARED_LIBRARY_RELEASE
+             NAMES GLEW glew glew32
+             PATH_SUFFIXES lib lib64 libx32 lib/Release/${_arch}
              PATHS ENV GLEW_ROOT)
 
-set(GLEW_INCLUDE_DIRS ${GLEW_INCLUDE_DIR})
-set(GLEW_LIBRARIES ${GLEW_LIBRARY})
+find_library(GLEW_SHARED_LIBRARY_DEBUG
+             NAMES GLEWd glewd glew32d
+             PATH_SUFFIXES lib lib64
+             PATHS ENV GLEW_ROOT)
+
+
+set_find_library_suffix(STATIC)
+
+find_library(GLEW_STATIC_LIBRARY_RELEASE
+             NAMES GLEW glew glew32s
+             PATH_SUFFIXES lib lib64 libx32 lib/Release/${_arch}
+             PATHS ENV GLEW_ROOT)
+
+find_library(GLEW_STATIC_LIBRARY_DEBUG
+             NAMES GLEWds glewds glew32ds
+             PATH_SUFFIXES lib lib64
+             PATHS ENV GLEW_ROOT)
+
+include(SelectLibraryConfigurations)
+select_library_configurations(GLEW_SHARED)
+select_library_configurations(GLEW_STATIC)
+if(NOT GLEW_USE_STATIC_LIBS)
+  set(GLEW_LIBRARIES ${GLEW_SHARED_LIBRARY})
+else()
+  set(GLEW_LIBRARIES ${GLEW_STATIC_LIBRARY})
+endif()
+
+
+if(GLEW_VERBOSE)
+  message(STATUS "FindGLEW: GLEW_SHARED_LIBRARY_RELEASE: ${GLEW_SHARED_LIBRARY_RELEASE}")
+  message(STATUS "FindGLEW: GLEW_STATIC_LIBRARY_RELEASE: ${GLEW_STATIC_LIBRARY_RELEASE}")
+  message(STATUS "FindGLEW: GLEW_SHARED_LIBRARY_DEBUG: ${GLEW_SHARED_LIBRARY_DEBUG}")
+  message(STATUS "FindGLEW: GLEW_STATIC_LIBRARY_DEBUG: ${GLEW_STATIC_LIBRARY_DEBUG}")
+  message(STATUS "FindGLEW: GLEW_SHARED_LIBRARY: ${GLEW_SHARED_LIBRARY}")
+  message(STATUS "FindGLEW: GLEW_STATIC_LIBRARY: ${GLEW_STATIC_LIBRARY}")
+  message(STATUS "FindGLEW: GLEW_LIBRARIES: ${GLEW_LIBRARIES}")
+endif()
+
+
+# Read version from GL/glew.h file
+if(EXISTS "${GLEW_INCLUDE_DIR}/GL/glew.h")
+  file(STRINGS "${GLEW_INCLUDE_DIR}/GL/glew.h" _contents REGEX "^VERSION_.+ [0-9]+")
+  if(_contents)
+    string(REGEX REPLACE ".*VERSION_MAJOR[ \t]+([0-9]+).*" "\\1" GLEW_VERSION_MAJOR "${_contents}")
+    string(REGEX REPLACE ".*VERSION_MINOR[ \t]+([0-9]+).*" "\\1" GLEW_VERSION_MINOR "${_contents}")
+    string(REGEX REPLACE ".*VERSION_MICRO[ \t]+([0-9]+).*" "\\1" GLEW_VERSION_MICRO "${_contents}")
+    set(GLEW_VERSION "${GLEW_VERSION_MAJOR}.${GLEW_VERSION_MINOR}.${GLEW_VERSION_MICRO}")
+  endif()
+endif()
+
+if(GLEW_VERBOSE)
+  message(STATUS "FindGLEW: GLEW_VERSION_MAJOR: ${GLEW_VERSION_MAJOR}")
+  message(STATUS "FindGLEW: GLEW_VERSION_MINOR: ${GLEW_VERSION_MINOR}")
+  message(STATUS "FindGLEW: GLEW_VERSION_MICRO: ${GLEW_VERSION_MICRO}")
+  message(STATUS "FindGLEW: GLEW_VERSION: ${GLEW_VERSION}")
+endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(GLEW
-                                  REQUIRED_VARS GLEW_INCLUDE_DIR GLEW_LIBRARY)
+                                  REQUIRED_VARS GLEW_INCLUDE_DIRS GLEW_LIBRARIES
+                                  VERSION_VAR GLEW_VERSION)
 
-if(GLEW_FOUND AND NOT TARGET GLEW::GLEW)
-  add_library(GLEW::GLEW UNKNOWN IMPORTED)
-  set_target_properties(GLEW::GLEW PROPERTIES
-    IMPORTED_LOCATION "${GLEW_LIBRARY}"
-    INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIRS}")
+if(NOT GLEW_FOUND)
+  if(GLEW_VERBOSE)
+    message(STATUS "FindGLEW: could not found GLEW library.")
+  endif()
+  return()
 endif()
 
-mark_as_advanced(GLEW_INCLUDE_DIR GLEW_LIBRARY)
+
+if(NOT TARGET GLEW::glew AND NOT GLEW_USE_STATIC_LIBS)
+  if(GLEW_VERBOSE)
+    message(STATUS "FindGLEW: Creating GLEW::glew imported target.")
+  endif()
+
+  add_library(GLEW::glew UNKNOWN IMPORTED)
+
+  set_target_properties(GLEW::glew
+                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIRS}")
+
+  if(GLEW_SHARED_LIBRARY_RELEASE)
+    set_property(TARGET GLEW::glew
+                 APPEND
+                 PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+
+    set_target_properties(GLEW::glew
+                          PROPERTIES IMPORTED_LOCATION_RELEASE "${GLEW_SHARED_LIBRARY_RELEASE}")
+  endif()
+
+  if(GLEW_SHARED_LIBRARY_DEBUG)
+    set_property(TARGET GLEW::glew
+                 APPEND
+                 PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+
+    set_target_properties(GLEW::glew
+                          PROPERTIES IMPORTED_LOCATION_DEBUG "${GLEW_SHARED_LIBRARY_DEBUG}")
+  endif()
+
+elseif(NOT TARGET GLEW::glew_s AND GLEW_USE_STATIC_LIBS)
+  if(GLEW_VERBOSE)
+    message(STATUS "FindGLEW: Creating GLEW::glew_s imported target.")
+  endif()
+
+  add_library(GLEW::glew_s UNKNOWN IMPORTED)
+
+  set_target_properties(GLEW::glew_s
+                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIRS}")
+
+  if(GLEW_STATIC_LIBRARY_RELEASE)
+    set_property(TARGET GLEW::glew_s
+                 APPEND
+                 PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+
+    set_target_properties(GLEW::glew_s
+                          PROPERTIES IMPORTED_LOCATION_RELEASE "${GLEW_STATIC_LIBRARY_RELEASE}")
+  endif()
+
+  if(GLEW_STATIC_LIBRARY_DEBUG)
+    set_property(TARGET GLEW::glew_s
+                 APPEND
+                 PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+
+    set_target_properties(GLEW::glew_s
+                          PROPERTIES IMPORTED_LOCATION_DEBUG "${GLEW_STATIC_LIBRARY_DEBUG}")
+  endif()
+endif()
+
+if(NOT TARGET GLEW::GLEW)
+  if(GLEW_VERBOSE)
+    message(STATUS "FindGLEW: Creating GLEW::GLEW imported target.")
+  endif()
+
+  add_library(GLEW::GLEW UNKNOWN IMPORTED)
+
+  set_target_properties(GLEW::GLEW
+                        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${GLEW_INCLUDE_DIRS}")
+
+  if(TARGET GLEW::glew)
+    if(GLEW_SHARED_LIBRARY_RELEASE)
+      set_property(TARGET GLEW::GLEW
+                   APPEND
+                   PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+
+      set_target_properties(GLEW::GLEW
+                            PROPERTIES IMPORTED_LOCATION_RELEASE "${GLEW_SHARED_LIBRARY_RELEASE}")
+    endif()
+
+    if(GLEW_SHARED_LIBRARY_DEBUG)
+      set_property(TARGET GLEW::GLEW
+                   APPEND
+                   PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+
+      set_target_properties(GLEW::GLEW
+                            PROPERTIES IMPORTED_LOCATION_DEBUG "${GLEW_SHARED_LIBRARY_DEBUG}")
+    endif()
+
+  elseif(TARGET GLEW::glew_s)
+    if(GLEW_STATIC_LIBRARY_RELEASE)
+      set_property(TARGET GLEW::GLEW
+                   APPEND
+                   PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
+
+      set_target_properties(GLEW::GLEW
+                            PROPERTIES IMPORTED_LOCATION_RELEASE "${GLEW_STATIC_LIBRARY_RELEASE}")
+    endif()
+
+    if(GLEW_STATIC_LIBRARY_DEBUG AND GLEW_USE_STATIC_LIBS)
+      set_property(TARGET GLEW::GLEW
+                   APPEND
+                   PROPERTY IMPORTED_CONFIGURATIONS DEBUG)
+
+      set_target_properties(GLEW::GLEW
+                            PROPERTIES IMPORTED_LOCATION_DEBUG "${GLEW_STATIC_LIBRARY_DEBUG}")
+    endif()
+
+  else()
+    message(FATAL_ERROR "FindGLEW: no `GLEW::glew` or `GLEW::glew_s` target was created. Something went wrong in FindGLEW target creation.")
+  endif()
+endif()

--- a/help/release/0.10.0.rst
+++ b/help/release/0.10.0.rst
@@ -32,6 +32,7 @@ Find Modules
 ------------
 
 * Import :module:`FindI2C` module from `YARP Git Repository`_.
+* Update :module:`FindGLEW` module to replicate upstream glew-config behaviour.
 
 
 CMake Next

--- a/modules/InstallBasicPackageFiles.cmake
+++ b/modules/InstallBasicPackageFiles.cmake
@@ -602,7 +602,7 @@ ${_compatibility_vars}
 
   unset(PACKAGE_DEPENDENCIES)
   if(DEFINED _IBPF_DEPENDENCIES)
-    set(PACKAGE_DEPENDENCIES "#### Expanded from @PACKAGE_DEPENDENCIES@ by install_basic_package_files() ####\n\ninclude(CMakeFindDependencyMacro)\n")
+    set(PACKAGE_DEPENDENCIES "\n#### Expanded from @PACKAGE_DEPENDENCIES@ by install_basic_package_files() ####\n\ninclude(CMakeFindDependencyMacro)\n")
 
     # FIXME When CMake 3.9 or greater is required, remove this madness and just
     #       use find_dependency


### PR DESCRIPTION
With this PR, I updated the FindGLEW module to replicate upstream behaviour and, in particular, to have the following features:
 - define the imported target `GLEW::glew` for the shared library GLEW;
 - if `GLEW_USE_STATIC_LIBS` is defined and set to `TRUE`, this module instad defines the imported target `GLEW::glew_s` for the static library GLEW;
 - an imported target `GLEW::GLEW` is created as a copy of either `GLEW::glew` or `GLEW::glew_s`;
 - by setting `GLEW_VERBOSE` you print out the log of the module.