### PR TITLE
`VERSION` now defaults to `PROJECT_VERSION` as advertised

### DIFF
--- a/modules/InstallBasicPackageFiles.cmake
+++ b/modules/InstallBasicPackageFiles.cmake
@@ -12,8 +12,8 @@
 # project::
 #
 #  install_basic_package_files(<Name>
-#                              VERSION <version>
 #                              COMPATIBILITY <compatibility>
+#                              [VERSION <version>]
 #                              [ARCH_INDEPENDENT]
 #                              [EXPORT <export>] # (default = "<Name>")
 #                              [NO_SET_AND_CHECK_MACRO]
@@ -260,7 +260,10 @@ function(INSTALL_BASIC_PACKAGE_FILES _Name)
   endif()
 
   if(NOT DEFINED _IBPF_VERSION)
-    message(FATAL_ERROR "VERSION argument is required")
+    if(NOT DEFINED PROJECT_VERSION)
+      message(FATAL_ERROR "VERSION argument is required (PROJECT_VERSION is not defined)")
+    endif()
+    set(_IBPF_VERSION ${PROJECT_VERSION})
   endif()
 
   if(NOT DEFINED _IBPF_COMPATIBILITY)


### PR DESCRIPTION
The documentation for `install_basic_package_files()` claims:

> If no ``VERSION`` is given, the ``PROJECT_VERSION`` variable is used.

However, this was not yet implemented, which this pull request aims to fix.