### PR TITLE
Minor documentation fixes/improvements

### DIFF
--- a/modules/InstallBasicPackageFiles.cmake
+++ b/modules/InstallBasicPackageFiles.cmake
@@ -196,6 +196,10 @@
 # This allows one to inject custom code to this file, useful e.g. to set
 # additional variables which are loaded by downstream projects.
 #
+# Note that content specified with ``INCLUDE_FILE`` or ``INCLUDE_CONTENT``
+# cannot reference any of the ``PATH_VARS`` because this content is not
+# expanded by :cmake:command:`configure_package_config_file`.
+#
 # If the ``COMPONENT`` argument is passed, it is forwarded to the
 # :cmake:command:`install` commands, otherwise ``<Name>`` is used.
 

--- a/modules/InstallBasicPackageFiles.cmake
+++ b/modules/InstallBasicPackageFiles.cmake
@@ -226,8 +226,6 @@ include(CMakeParseArguments)
 
 function(INSTALL_BASIC_PACKAGE_FILES _Name)
 
-  # TODO check that _Name does not contain "-" characters
-
   set(_options ARCH_INDEPENDENT
                NO_SET_AND_CHECK_MACRO
                NO_CHECK_REQUIRED_COMPONENTS_MACRO

--- a/modules/InstallBasicPackageFiles.cmake
+++ b/modules/InstallBasicPackageFiles.cmake
@@ -39,16 +39,16 @@
 #  - ``<Name>Targets.cmake`` or ``<name>-targets.cmake``
 #
 # If neither ``UPPERCASE_FILENAMES`` nor ``LOWERCASE_FILENAMES`` is
-# set, a file ``<Name>ConfigVersion.cmake.in`` or
-# ``<name>-config-version.cmake.in`` is searched, and the convention
+# set, a file ``<Name>Config.cmake.in`` or
+# ``<name>-config.cmake.in`` is searched, and the convention
 # is chosed according to the file found. If no file was found, the
 # uppercase convention is used.
 #
 # The ``DEPENDENCIES`` argument can be used to set a list of dependencies
-# that will be searched using the :command:`find_dependency` command
+# that will be searched using the :cmake:command:`find_dependency` command
 # from the :module:`CMakeFindDependencyMacro` module.
-# Dependencies can be followed by any of the possible :command:`find_dependency`
-# argument.
+# Dependencies can be followed by any of the possible
+# :cmake:command:`find_dependency` argument.
 # In this case, all the arguments must be specified within double quotes (e.g.
 # ``"<dependency> 1.0.0 EXACT"``, or ``"<dependency> CONFIG"``).
 # The ``PRIVATE_DEPENDENCIES`` argument is similar to ``DEPENDENCIES``, but
@@ -73,8 +73,9 @@
 # considered relative to the ``CMAKE_CURRENT_BINARY_DIR`` directory.
 #
 # The ``<Name>ConfigVersion.cmake`` file is generated using
-# ``write_basic_package_version_file``. The ``VERSION``, ``COMPATIBILITY``, and
-# ``ARCH_INDEPENDENT``arguments are passed to this function.
+# :cmake:command:`write_basic_package_version_file`. The ``VERSION``,
+# ``COMPATIBILITY``, and ``ARCH_INDEPENDENT``arguments are passed to this
+# function.
 #
 # ``VERSION`` shall be in the form ``<major>[.<minor>[.<patch>[.<tweak>]]]]``.
 # If no ``VERSION`` is given, the ``PROJECT_VERSION`` variable is used.
@@ -82,12 +83,12 @@
 # to replace the ``@PACKAGE_VERSION@`` string in the configuration file.
 #
 # ``COMPATIBILITY`` shall be any of the options accepted by the
-# :command:`write_basic_package_version_file` command
+# :cmake:command:`write_basic_package_version_file` command
 # (``AnyNewerVersion``, ``SameMajorVersion``, ``SameMinorVersion`` [CMake 3.11],
 # or ``ExactVersion``).
-# These options are explained in :command:`write_basic_package_version_file`
+# These options are explained in :cmake:command:`write_basic_package_version_file`
 # command documentation.
-# If your project has more elaborated version matching rules, you will need to
+# If your project has more elaborate version matching rules, you will need to
 # write your own custom ConfigVersion.cmake file instead of using this macro.
 #
 # If the ``ARCH_INDEPENDENT`` option is enabled, the installed package version
@@ -95,14 +96,14 @@
 # architecture than the requested architecture.
 #
 # The ``<Name>Config.cmake`` file is generated using
-# ``configure_package_config_file``. The  ``NO_SET_AND_CHECK_MACRO``, and
-# ``NO_CHECK_REQUIRED_COMPONENTS_MACRO``, and arguments are passed to this
-# function.
+# :cmake:command:`configure_package_config_file`. The
+# ``NO_SET_AND_CHECK_MACRO``, ``NO_CHECK_REQUIRED_COMPONENTS_MACRO``, and
+# arguments are passed to this function.
 #
-# By default ``install_basic_package_files`` also generates the two helper
+# By default :command:`install_basic_package_files` also generates the two helper
 # macros ``set_and_check()`` and ``check_required_components()`` into the
 # ``<Name>Config.cmake`` file. ``set_and_check()`` should be used instead of the
-# normal :command:`set()` command for setting directories and file locations.
+# normal :cmake:command:`set()` command for setting directories and file locations.
 # Additionally to setting the variable it also checks that the referenced file
 # or directory actually exists and fails with a ``FATAL_ERROR`` otherwise.
 # This makes sure that the created ``<Name>Config.cmake`` file does not contain
@@ -110,7 +111,7 @@
 # When using the ``NO_SET_AND_CHECK_MACRO, this macro is not generated into the
 # ``<Name>Config.cmake`` file.
 #
-# By default, ``install_basic_package_files`` append a call to
+# By default, :command:`install_basic_package_files` append a call to
 # ``check_required_components(<Name>)`` in ``<Name>Config.cmake`` file if the
 # package supports components. This macro checks whether all requested,
 # non-optional components have been found, and if this is not the case, sets the
@@ -132,7 +133,7 @@
 # If the file does not exist, a very basic file is created.
 #
 # A set of variables are checked and passed to
-# ``configure_package_config_file`` as ``PATH_VARS``. For each of the
+# :cmake:command:`configure_package_config_file` as ``PATH_VARS``. For each of the
 # ``SUFFIX`` considered, if one of the variables::
 #
 #     <VARS_PREFIX>_(BUILD|INSTALL)_<SUFFIX>
@@ -177,16 +178,16 @@
 # argument.
 #
 #
-# The ``<Name>Targets.cmake`` is generated using :command:`export(EXPORT)` in
-# the build tree and :command:`install(EXPORT)` in the installation directory.
-# The targets are exported using the value for the ``NAMESPACE`` argument as
-# namespace.
+# The ``<Name>Targets.cmake`` is generated using :cmake:command:`export(EXPORT)`
+# in the build tree and :cmake:command:`install(EXPORT)` in the installation
+# directory. The targets are exported using the value for the ``NAMESPACE``
+# argument as namespace.
 # The export can be passed using the ``EXPORT`` argument.
 #
 # If the ``INCLUDE_FILE`` argument is passed, the content of the specified file
 # (which might contain ``@variables@``) is appended to the generated
 # ``<Name>Config.cmake`` file.
-# If the ``INCLUDED_CONTENT`` argument is passed, the specified content
+# If the ``INCLUDE_CONTENT`` argument is passed, the specified content
 # (which might contain ``@variables@``) is appended to the generated
 # ``<Name>Config.cmake`` file.
 # When a ``CONFIG_TEMPLATE`` is passed, or a ``<Name>ConfigVersion.cmake.in`` or
@@ -196,7 +197,7 @@
 # additional variables which are loaded by downstream projects.
 #
 # If the ``COMPONENT`` argument is passed, it is forwarded to the
-# :command:`install` commands, otherwise ``<Name>`` is used.
+# :cmake:command:`install` commands, otherwise ``<Name>`` is used.
 
 #=============================================================================
 # Copyright 2013 Istituto Italiano di Tecnologia (IIT)


### PR DESCRIPTION
This PR addresses several minor things in the docs and comments.

The remark on `PATH_VARS` and `INCLUDE_FILE|INCLUDE_CONTENT` in https://github.com/robotology/ycm/commit/b3a1289716222f0a3f369f6c4184df5c723a0497 documents something which might be a design problem. `install_basic_package_files()` uses `string(CONFIGURE)` to expand `@...@` variables in the included content and then stores the expanded content in a variable `INCLUDED_CONTENT` which is subsequently expanded into the config file by `configure_package_config_file()`. Because variable substitution in `configure_file()` is not recursive (as far as I can tell), this implies that included content doesn't have access to the `PATH_VARS` variables. To use these, it is necessary to provide a custom config file.