### PR TITLE
FindIPOPT: avoid hardcoding IPOPT_INCLUDE_DIRS to  ${IPOPT_DIR}/include/coin

### DIFF
--- a/find-modules/FindIPOPT.cmake
+++ b/find-modules/FindIPOPT.cmake
@@ -82,7 +82,8 @@ if(NOT WIN32)
       set(IPOPT_DIR /usr            CACHE PATH "Path to IPOPT build directory")
     endif()
 
-    set(IPOPT_INCLUDE_DIRS ${IPOPT_DIR}/include/coin)
+    find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp coin/IpIpoptApplication.hpp PATHS ${IPOPT_DIR}/include/coin)
+    
     find_library(IPOPT_LIBRARIES ipopt ${IPOPT_DIR}/lib
                                      ${IPOPT_DIR}/lib/coin
                                      NO_DEFAULT_PATH)
@@ -129,8 +130,9 @@ else()
   include(SelectLibraryConfigurations)
 
   set(IPOPT_DIR $ENV{IPOPT_DIR} CACHE PATH "Path to IPOPT build directory")
+  
+  find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp coin/IpIpoptApplication.hpp PATHS ${IPOPT_DIR}/include/coin)
 
-  set(IPOPT_INCLUDE_DIRS ${IPOPT_DIR}/include/coin)
   find_library(IPOPT_IPOPT_LIBRARY_RELEASE libipopt ${IPOPT_DIR}/lib
                                                     ${IPOPT_DIR}/lib/coin
                                                     NO_DEFAULT_PATH)


### PR DESCRIPTION
Instead, search for the IpOpt headers using the standard find_path CMake command. 

Fix https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports/issues/3 .