### PR TITLE
FindIPOPT: Remove use of NO_DEFAULT_PATH

### DIFF
--- a/find-modules/FindIPOPT.cmake
+++ b/find-modules/FindIPOPT.cmake
@@ -85,13 +85,11 @@ if(NOT WIN32)
     find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp coin/IpIpoptApplication.hpp PATHS ${IPOPT_DIR}/include/coin)
     
     find_library(IPOPT_LIBRARIES ipopt ${IPOPT_DIR}/lib
-                                     ${IPOPT_DIR}/lib/coin
-                                     NO_DEFAULT_PATH)
+                                     ${IPOPT_DIR}/lib/coin)
 
     if(IPOPT_LIBRARIES)
       find_file(IPOPT_DEP_FILE ipopt_addlibs_cpp.txt ${IPOPT_DIR}/share/doc/coin/Ipopt
-                                                     ${IPOPT_DIR}/share/coin/doc/Ipopt
-                                                     NO_DEFAULT_PATH)
+                                                     ${IPOPT_DIR}/share/coin/doc/Ipopt)
       mark_as_advanced(IPOPT_DEP_FILE)
 
       if(IPOPT_DEP_FILE)
@@ -107,8 +105,7 @@ if(NOT WIN32)
         foreach(LIB ${IPOPT_DEP})
           find_library(IPOPT_SEARCH_FOR_${LIB} ${LIB} ${IPOPT_DIR}/lib
                                                       ${IPOPT_DIR}/lib/coin
-                                                      ${IPOPT_DIR}/lib/coin/ThirdParty
-                                                      NO_DEFAULT_PATH)
+                                                      ${IPOPT_DIR}/lib/coin/ThirdParty)
           if(IPOPT_SEARCH_FOR_${LIB})
             # handle non-system libraries (e.g. coinblas)
             set(IPOPT_LIBRARIES ${IPOPT_LIBRARIES} ${IPOPT_SEARCH_FOR_${LIB}})
@@ -134,11 +131,9 @@ else()
   find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp coin/IpIpoptApplication.hpp PATHS ${IPOPT_DIR}/include/coin)
 
   find_library(IPOPT_IPOPT_LIBRARY_RELEASE libipopt ${IPOPT_DIR}/lib
-                                                    ${IPOPT_DIR}/lib/coin
-                                                    NO_DEFAULT_PATH)
+                                                    ${IPOPT_DIR}/lib/coin)
   find_library(IPOPT_IPOPT_LIBRARY_DEBUG   libipoptD ${IPOPT_DIR}/lib
-                                                     ${IPOPT_DIR}/lib/coin
-                                                     NO_DEFAULT_PATH)
+                                                     ${IPOPT_DIR}/lib/coin)
 
   select_library_configurations(IPOPT_IPOPT)
   set(IPOPT_LIBRARIES ${IPOPT_IPOPT_LIBRARY})


### PR DESCRIPTION
The use of NO_DEFAULT_PATH complicates finding the library using the standard enviroment variables such as CMAKE_PREFIX_PATH.