### PR TITLE
YCMEPHelper: Introduce YCM_EP_INSTALL_DIR advanced variable

### DIFF
--- a/help/manual/ycm-superbuild.7.rst
+++ b/help/manual/ycm-superbuild.7.rst
@@ -83,8 +83,9 @@ the superbuild will download and install all the required projects that
 cannot be found on the system.
 
 After the build, all the subprojects will be installed inside the
-``build/install`` folder, therefore in order to use it you will
-have to adjust some environment variables
+``${YCM_EP_INSTALL_DIR}`` folder (by default ``${CMAKE_BINARY_DIR}/install``,
+i.e. ``build/install``), therefore in order to use it you will have to adjust
+some environment variables
 
 .. code-block:: sh
 
@@ -160,10 +161,10 @@ explicitly specify the configuration at command line:
    #Release
    xcodebuild -configuration Release
 
-
 After the build, all the subprojects will be installed inside the
-``build/install`` folder, therefore in order to use it you will
-have to adjust some environment variables
+``${YCM_EP_INSTALL_DIR}`` folder (by default ``${CMAKE_BINARY_DIR}/install``,
+i.e. ``build/install``), therefore in order to use it you will have to adjust
+some environment variables
 
 .. code-block:: sh
 
@@ -275,7 +276,15 @@ YCM superbuild project, usually ``${PROJECT_SOURCE_DIR}/build/``
 The superbuild will run the ``configure``, ``build`` and ``install``
 step for each project.
 
-Each project will be installed in ``${PROJECT_BINARY_DIR}/install``
+Each project will be installed in ``${YCM_EP_INSTALL_DIR}`` (by default
+``${PROJECT_BINARY_DIR}/install``).
+You should not change the ``YCM_EP_INSTALL_DIR`` variable, unless you wish to
+build the superbuild only once, and discard the build directory. In this case
+you should change this variable to the final destination of the build since, for
+many projects, the build is not relocatable.
+Please also note that, if you change it to a folder that is not writable by
+current user, you will have to run the whole build as superuser.
+
 
 
 .. _`Developer Mode`:

--- a/help/release/0.11.0.rst
+++ b/help/release/0.11.0.rst
@@ -26,3 +26,16 @@ Generic Modules
 * :module:`InstallBasicPackageFiles`: Added the new ``NO_EXPORT`` option, that
   can be used to install a set of CMake files when you don't have an export set
   or any targets to export.
+
+Superbuild Modules
+------------------
+
+* :module:`YCMEPHelper`: The ``YCM_EP_INSTALL_DIR`` variable can be used to
+  change where the subprojects will be installed (default
+  ``${PROJECT_BINARY_DIR}/install``).
+  You should not change the ``YCM_EP_INSTALL_DIR`` variable, unless you wish to
+  build the superbuild only once, and discard the build directory. In this case
+  you should change this variable to the final destination of the build since,
+  for many projects, the build is not relocatable.
+  Please also note that, if you change it to a folder that is not writable by
+  current user, you will have to run the whole build as superuser.

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -47,6 +47,8 @@
 #
 # .. variable:: YCM_BOOTSTRAP_VERBOSE
 #
+# .. variable:: YCM_EP_INSTALL_DIR
+#
 # .. variable:: YCM_<COMPONENT>_COLOR
 #
 # .. variable:: YCM_<COMPONENT>_BGCOLOR
@@ -230,7 +232,8 @@ macro(_YCM_SETUP)
   # Install directory for all sub-projects
   # TODO Make this a cached variable for installation outside build
   #      directory
-  set(_YCM_EP_INSTALL_DIR ${CMAKE_BINARY_DIR}/install)
+  set(YCM_EP_INSTALL_DIR "${CMAKE_BINARY_DIR}/install" CACHE PATH "Path to the superbuild installation directory. WARNING: If this path is not writable by the user, you will have to build as superuser")
+  mark_as_advanced(YCM_EP_INSTALL_DIR)
 
   # ExternalProject does not handle correctly arguments containing ";" passed
   # using CMAKE_ARGS, and instead splits them into several arguments. This is
@@ -239,7 +242,7 @@ macro(_YCM_SETUP)
   #
   # TODO FIXME check what happens when the "*_COMMAND" arguments are passed.
   file(TO_CMAKE_PATH "$ENV{CMAKE_PREFIX_PATH}" _CMAKE_PREFIX_PATH)
-  list(INSERT _CMAKE_PREFIX_PATH 0 ${_YCM_EP_INSTALL_DIR})
+  list(INSERT _CMAKE_PREFIX_PATH 0 ${YCM_EP_INSTALL_DIR})
   list(REMOVE_DUPLICATES _CMAKE_PREFIX_PATH)
   string(REPLACE ";" "|" _CMAKE_PREFIX_PATH "${_CMAKE_PREFIX_PATH}")
   set(_YCM_EP_ALL_CMAKE_ARGS LIST_SEPARATOR "|")
@@ -249,7 +252,7 @@ macro(_YCM_SETUP)
                          "-DCMAKE_PREFIX_PATH:PATH=${_CMAKE_PREFIX_PATH}") # Path used by cmake for finding stuff
 
   # Default CMAKE_CACHE_ARGS (Initial cache, forced)
-  set(_YCM_EP_CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:PATH=${_YCM_EP_INSTALL_DIR}") # Where to do the installation
+  set(_YCM_EP_CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:PATH=${YCM_EP_INSTALL_DIR}") # Where to do the installation
 
   if(DEFINED CMAKE_TOOLCHAIN_FILE)
     list(APPEND _YCM_EP_CMAKE_CACHE_ARGS "-DCMAKE_TOOLCHAIN_FILE:PATH=${CMAKE_TOOLCHAIN_FILE}")
@@ -817,7 +820,7 @@ function(YCM_EP_HELPER _name)
   set(${_name}_SOURCE_DIR ${CMAKE_SOURCE_DIR}/${_YH_${_name}_FOLDER}/${_name})
   set(${_name}_DOWNLOAD_DIR ${CMAKE_SOURCE_DIR}/${_YH_${_name}_FOLDER})
   set(${_name}_BINARY_DIR ${CMAKE_BINARY_DIR}/${_YH_${_name}_FOLDER}/${_name})
-  set(${_name}_INSTALL_DIR ${_YCM_EP_INSTALL_DIR})
+  set(${_name}_INSTALL_DIR ${YCM_EP_INSTALL_DIR})
   set(${_name}_TMP_DIR ${CMAKE_BINARY_DIR}/${_YH_${_name}_FOLDER}/${_name}${CMAKE_FILES_DIRECTORY}/YCMTmp)
   set(${_name}_STAMP_DIR ${CMAKE_BINARY_DIR}/${_YH_${_name}_FOLDER}/${_name}${CMAKE_FILES_DIRECTORY}/YCMStamp)
 
@@ -894,7 +897,7 @@ function(YCM_EP_HELPER _name)
      NOT ("${_YH_${_name}_CONFIGURE_COMMAND}" MATCHES "^[^;]*/cmake" AND
           NOT "${_YH_${_name}_CONFIGURE_COMMAND}" MATCHES ";-[PE];"))
 
-    set(_pkg_config_path "${_YCM_EP_INSTALL_DIR}/lib/pkgconfig")
+    set(_pkg_config_path "${YCM_EP_INSTALL_DIR}/lib/pkgconfig")
     if(WIN32)
       set(_regex "(^|;)${_pkg_config_path}(;|^)")
     else()


### PR DESCRIPTION
The `YCM_EP_INSTALL_DIR` variable can be used to change where the subprojects will be installed (default `${PROJECT_BINARY_DIR}/install`).

You should not change the `YCM_EP_INSTALL_DIR` variable, unless you wish to build the superbuild only once, and discard the build directory.
In this case you should change this variable to the final destination of the build since, for many projects, the build is not relocatable.

Please also note that, if you change it to a folder that is not writable by current user, you will have to run the whole build as superuser.