### PR TITLE
Fix FindTinyXML.cmake script to work fine with vcpkg's installed tinyxml

### DIFF
--- a/find-modules/FindTinyXML.cmake
+++ b/find-modules/FindTinyXML.cmake
@@ -30,7 +30,8 @@
 
 
 include(StandardFindModule)
-standard_find_module(TinyXML tinyxml)
+standard_find_module(TinyXML tinyxml
+                     SKIP_CMAKE_CONFIG)
 
 # Set package properties if FeatureSummary was included
 if(COMMAND set_package_properties)


### PR DESCRIPTION
Unfortunately, vcpkg installs a really bad and custom `tinyxml-config.cmake` file (see https://github.com/robotology/robot-testing-framework/issues/107 and https://github.com/microsoft/vcpkg/pull/5544). As TinyXML has long been abandoned upstream, I think any CMake config we can find are something provided by packagers that have the high probability of breaking downstream user CMake logic, so I think the best option is just to disable searching for CMake config files at all for TinyXML. 