### PR TITLE
Remove NO_DEFAULT_PATH from ESDCANAPI find_library

### DIFF
--- a/find-modules/FindESDCANAPI.cmake
+++ b/find-modules/FindESDCANAPI.cmake
@@ -68,8 +68,7 @@ if(NOT ESDCANAPI_FOUND)
     # Find library
     find_library(ESDCANAPI_LIB
                  NAMES "ntcan"
-                 PATHS ${ESDCAN_LIB_DIRS}
-                 NO_DEFAULT_PATH)
+                 PATHS ${ESDCAN_LIB_DIRS})
 
     # Find include file
     find_path(ESDCANAPI_INC_DIRS


### PR DESCRIPTION
If the ESDCANAPI ntcan library is installed via a custom vcpkg port instead of the official installers, 
its location will not be already listed in the `ESDCAN_LIB_DIRS`, and instead  would be found with the usual `CMAKE_PREFIX_PATH` introspection. 

Note that the precedence will remain on the PATHS specified by `ESDCAN_LIB_DIRS`, so we do not risk to break any existing behavior with this change.