### PR TITLE
Fix find_path call to search for IPOPT_INCLUDE_DIRS

### DIFF
--- a/find-modules/FindIPOPT.cmake
+++ b/find-modules/FindIPOPT.cmake
@@ -82,7 +82,7 @@ if(NOT WIN32)
       set(IPOPT_DIR /usr            CACHE PATH "Path to IPOPT build directory")
     endif()
 
-    find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp coin/IpIpoptApplication.hpp PATHS ${IPOPT_DIR}/include/coin)
+    find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp PATH_SUFFIXES coin PATHS ${IPOPT_DIR}/include/coin)
     
     find_library(IPOPT_LIBRARIES ipopt ${IPOPT_DIR}/lib
                                      ${IPOPT_DIR}/lib/coin)
@@ -128,7 +128,7 @@ else()
 
   set(IPOPT_DIR $ENV{IPOPT_DIR} CACHE PATH "Path to IPOPT build directory")
   
-  find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp coin/IpIpoptApplication.hpp PATHS ${IPOPT_DIR}/include/coin)
+  find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp PATH_SUFFIXES coin PATHS ${IPOPT_DIR}/include/coin)
 
   find_library(IPOPT_IPOPT_LIBRARY_RELEASE libipopt ${IPOPT_DIR}/lib
                                                     ${IPOPT_DIR}/lib/coin)


### PR DESCRIPTION
I  was using a recent CMake (3.17) on Windows, and for IPOPT_INCLUDE_DIRS the `FindIPOPT.cmake` script was finding the wrong path `C:/robotology/vcpkg/installed/x64-windows/include/coin` instead of the correct `C:/robotology/vcpkg/installed/x64-windows/include`. Note that all uses of IPOPT headers, even in their examples (see https://github.com/coin-or/Ipopt/blob/releases/3.13.1/examples/Cpp_example/MyNLP.hpp) use the direct inclusion of the headers (i.e. `#include <IpTNLP.hpp>`, not `#include <coin/IpTNLP.hpp>`. 

With this fix, the `FindIPOPT.cmake` should never find the wrong include path for IPOPT. To be honest, I do not know why it we never noticed this problem, it is possible that something subtle changed at the CMake level in CMake 3.17). 