### PR TITLE
FindOrBuildPackage: add YCM_FOBP_USE_SYSTEM_DEFAULT

### DIFF
--- a/help/manual/ycm-superbuild.7.rst
+++ b/help/manual/ycm-superbuild.7.rst
@@ -62,7 +62,7 @@ A YCM superbuild can be built like any other CMake project.
 Linux
 -----
 
-Suppose ``<YOUR_PROJECT>`` is the directory in which you downloaded the superbuild project 
+Suppose ``<YOUR_PROJECT>`` is the directory in which you downloaded the superbuild project
 you want to build:
 
 .. code-block:: sh
@@ -241,6 +241,9 @@ but also wants to modify some of the subprojects.
   the system version, and download and build it instead.
   This can be done by setting the ``USE_SYSTEM_<PACKAGE>`` variable to
   ``FALSE``.
+  To change the initial value of the ``USE_SYSTEM_<PACKAGE>`` variable,
+  you can set the ``YCM_FOBP_USE_SYSTEM_DEFAULT`` CMake variable to the
+  initial value you prefer.
 
 This can be done by running :cmake:manual:`ccmake <ccmake(1)>` or
 :cmake:manual:`cmake-gui <cmake-gui(1)>` and changing the value, or by

--- a/help/release/0.12.0.rst
+++ b/help/release/0.12.0.rst
@@ -39,3 +39,9 @@ Generic Modules
 * The :module:`InstallBasicPackageFiles` default for `INSTALL_DESTINATION` when
   ``ARCH_INDEPENDENT`` is passed is now
   ``${CMAKE_INSTALL_DATADIR}/cmake/<Name>``.
+
+Superbuild Modules
+------------------
+
+* :module:`FindOrBuildPackage`: Add ``YCM_FOBP_USE_SYSTEM_DEFAULT`` CMake variable
+  to set the initial value of ``USE_SYSTEM_<PACKAGE>`` variables.

--- a/modules/FindOrBuildPackage.cmake
+++ b/modules/FindOrBuildPackage.cmake
@@ -32,7 +32,10 @@
 #
 # If the package was found, the ``USE_SYSTEM_<PackageName>`` cached
 # variable can be disabled in order to force CMake to build the package
-# instead of using the one found on the system.
+# instead of using the one found on the system. The initial value of
+# ``USE_SYSTEM_<PackageName>`` variable is by default ``ON``, unless the
+# variable ``YCM_FOBP_USE_SYSTEM_DEFAULT`` is set, in that case the
+# initial value is the value of ``YCM_FOBP_USE_SYSTEM_DEFAULT``.
 #
 # This function sets these variables::
 #
@@ -171,7 +174,11 @@ function(FIND_OR_BUILD_PACKAGE _pkg)
         list(REMOVE_DUPLICATES _ycm_projects)
         set_property(GLOBAL PROPERTY YCM_PROJECTS ${_ycm_projects})
     endif()
-    cmake_dependent_option(USE_SYSTEM_${_PKG} "Use system installed ${_pkg}" ON "HAVE_SYSTEM_${_PKG}" OFF)
+    set(USE_SYSTEM_${_PKG}_INITIAL_VALUE OFF)
+    if(DEFINED YCM_FOBP_USE_SYSTEM_DEFAULT)
+        set(USE_SYSTEM_${_PKG}_INITIAL_VALUE ${YCM_FOBP_USE_SYSTEM_DEFAULT})
+    endif()
+    cmake_dependent_option(USE_SYSTEM_${_PKG} "Use system installed ${_pkg}" ON "HAVE_SYSTEM_${_PKG}" ${USE_SYSTEM_${_PKG}_INITIAL_VALUE})
     mark_as_advanced(USE_SYSTEM_${_PKG})
 
 


### PR DESCRIPTION
If defined, this variable can be used to set the initial value of the USE_SYSTEM_<PACKAGE> variables.

Fix https://github.com/robotology/ycm/issues/322 .