### PR TITLE
Fix FindOctave.cmake for Octave 5

### DIFF
--- a/3rdparty/cmake-wiki/FindOctave.cmake
+++ b/3rdparty/cmake-wiki/FindOctave.cmake
@@ -15,7 +15,6 @@
 #  OCTAVE_PATCH_VERSION        - patch version
 #  OCTAVE_OCT_FILE_DIR         - object files that will be dynamically loaded
 #  OCTAVE_OCT_LIB_DIR          - oct libraries
-#  OCTAVE_ROOT_DIR             - octave prefix
 #
 # The macro octave_add_oct allows to create compiled modules.
 # octave_add_oct ( target_name
@@ -24,12 +23,6 @@
 #         [EXTENSION ext]
 # )
 #
-# To install it, you can the use the variable OCTAVE_OCT_FILE_DIR as follow:
-#  file ( RELATIVE_PATH PKG_OCTAVE_OCT_FILE_DIR ${OCTAVE_ROOT_DIR} ${OCTAVE_OCT_FILE_DIR} )
-#  install (
-#    TARGETS target_name
-#    DESTINATION ${PKG_OCTAVE_OCT_FILE_DIR}
-#  )
 #=============================================================================
 # Copyright 2013, Julien Schueller
 # All rights reserved.
@@ -61,10 +54,6 @@ find_program( OCTAVE_CONFIG_EXECUTABLE
               NAMES octave-config
             )
 if ( OCTAVE_CONFIG_EXECUTABLE )
-  execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p PREFIX
-                    OUTPUT_VARIABLE OCTAVE_ROOT_DIR
-                    OUTPUT_STRIP_TRAILING_WHITESPACE )
-
   execute_process ( COMMAND ${OCTAVE_CONFIG_EXECUTABLE} -p BINDIR
                     OUTPUT_VARIABLE OCTAVE_BIN_PATHS
                     OUTPUT_STRIP_TRAILING_WHITESPACE )
@@ -157,9 +146,9 @@ endmacro ()
 # handle REQUIRED and QUIET options
 include ( FindPackageHandleStandardArgs )
 if ( CMAKE_VERSION LESS 2.8.3 )
-  find_package_handle_standard_args ( Octave DEFAULT_MSG OCTAVE_EXECUTABLE OCTAVE_ROOT_DIR OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES OCTAVE_VERSION_STRING )
+  find_package_handle_standard_args ( Octave DEFAULT_MSG OCTAVE_EXECUTABLE OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES OCTAVE_VERSION_STRING )
 else ()
-  find_package_handle_standard_args ( Octave REQUIRED_VARS OCTAVE_EXECUTABLE OCTAVE_ROOT_DIR OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES VERSION_VAR OCTAVE_VERSION_STRING )
+  find_package_handle_standard_args ( Octave REQUIRED_VARS OCTAVE_EXECUTABLE OCTAVE_INCLUDE_DIRS OCTAVE_LIBRARIES VERSION_VAR OCTAVE_VERSION_STRING )
 endif ()
 mark_as_advanced (
   OCTAVE_OCT_FILE_DIR
@@ -170,7 +159,6 @@ mark_as_advanced (
   OCTAVE_LIBRARIES
   OCTAVE_INCLUDE_DIR
   OCTAVE_INCLUDE_DIRS
-  OCTAVE_ROOT_DIR
   OCTAVE_VERSION_STRING
   OCTAVE_MAJOR_VERSION
   OCTAVE_MINOR_VERSION


### PR DESCRIPTION
See the related discussions in: 
* https://github.com/robotology/idyntree/pull/677
* https://discourse.cmake.org/t/findoctave-cmake-in-cmake-community-wiki-broken-for-octave-5/1079

As the support for obtaining the `PREFIX` variable (that in CMake was stored as `OCTAVE_ROOT_DIR`) was removed in Octave upstream.
I think it is easier and less error prone (fail early, fail fast) to just remove support for the variable, so in the remote case that anyone relies on this variable, he will notice that automatically as soon as he updates his YCM version, instead of getting a failure when someone compiles his project with Octave 5.
This is also the reason why I propose this for the master branch and not for the `ycm-0.11` branch.

cc @lrapetti 