### PR TITLE
Fix handling of PRIVATE_DEPENDENCIES in install_basic_package_files

### DIFF
--- a/help/release/0.11.2.rst
+++ b/help/release/0.11.2.rst
@@ -10,6 +10,12 @@ Changes made since YCM 0.11.1 include the following.
 Modules
 =======
 
+Generic Modules
+---------------
+
+* :module:`InstallBasicPackageFiles`: Fixed handling of PRIVATE_DEPENDENCIES
+  in install_basic_package_files. (#339)
+
 3rd Party
 ---------
 

--- a/modules/InstallBasicPackageFiles.cmake
+++ b/modules/InstallBasicPackageFiles.cmake
@@ -612,7 +612,7 @@ ${_compatibility_vars}
   endif()
 
   unset(PACKAGE_DEPENDENCIES)
-  if(DEFINED _IBPF_DEPENDENCIES)
+  if(DEFINED _IBPF_DEPENDENCIES OR (DEFINED _IBPF_PRIVATE_DEPENDENCIES AND _need_private_deps))
     set(PACKAGE_DEPENDENCIES "#### Expanded from @PACKAGE_DEPENDENCIES@ by install_basic_package_files() ####\n\ninclude(CMakeFindDependencyMacro)\n")
 
     # FIXME When CMake 3.9 or greater is required, remove this madness and just


### PR DESCRIPTION
Before the commit the PRIVATE_DEPENDENCIES argument of install_basic_package_files was ignored unless DEPENDENCIES was also set.