### PR TITLE
AddInstallRPATHSupport: Add target_append_install_rpath command

### DIFF
--- a/help/release/0.12.0.rst
+++ b/help/release/0.12.0.rst
@@ -39,6 +39,9 @@ Generic Modules
 * The :module:`InstallBasicPackageFiles` default for `INSTALL_DESTINATION` when
   ``ARCH_INDEPENDENT`` is passed is now
   ``${CMAKE_INSTALL_DATADIR}/cmake/<Name>``.
+* Added the new :command:`target_append_install_rpath` to the
+  :module:`AddInstallRPATHSupport` module, to modify the rpath for a single
+  target.
 
 Superbuild Modules
 ------------------

--- a/modules/AddInstallRPATHSupport.cmake
+++ b/modules/AddInstallRPATHSupport.cmake
@@ -83,9 +83,50 @@ Add support to RPATH during installation to the project and the targets
   Note: see https://gitlab.kitware.com/cmake/cmake/issues/16589 for further
   details.
 
+.. command:: target_append_install_rpath
+
+  Add extra paths to RPATH for a specific target::
+
+  .. code-block:: cmake
+
+    target_append_install_rpath(<target>
+                                <INSTALL_DESTINATION destination>
+                                [LIB_DIRS dir [dir]]
+                                [DEPENDS condition [condition]])
+
+  Arguments:
+   - ``INSTALL_DESTINATION`` path where the target will be installed.
+   - ``LIB_DIRS`` list of directories to be added to the RPATH. These
+     directories will be added "relative" w.r.t. the ``INSTALL_DESTINATION``.
+   - ``DEPENDS`` list of conditions that should be ``TRUE`` to enable
+     RPATH, for example ``FOO; NOT BAR``.
+
 #]=======================================================================]
 
 include(CMakeParseArguments)
+
+
+macro(__AddInstallRPATHSupport_GET_SYSTEM_LIB_DIRS _var)
+  # Find system implicit lib directories
+  set(${_var} ${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES})
+  if(EXISTS "/etc/debian_version") # is this a debian system ?
+    if(CMAKE_LIBRARY_ARCHITECTURE)
+      list(APPEND ${_var} "/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
+                          "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
+    endif()
+  endif()
+endmacro()
+
+
+macro(__AddInstallRPATHSupport_APPEND_RELATIVE_RPATH _var _bin_dir _lib_dir)
+  file(RELATIVE_PATH _rel_path ${_bin_dir} ${_lib_dir})
+  if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    list(APPEND ${_var} "@loader_path/${_rel_path}")
+  else()
+    list(APPEND ${_var} "\$ORIGIN/${_rel_path}")
+  endif()
+endmacro()
+
 
 
 function(ADD_INSTALL_RPATH_SUPPORT)
@@ -129,25 +170,14 @@ function(ADD_INSTALL_RPATH_SUPPORT)
     # Enable RPATH on OSX.
     set(CMAKE_MACOSX_RPATH TRUE PARENT_SCOPE)
 
-    # Find system implicit lib directories
-    set(_system_lib_dirs ${CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES})
-    if(EXISTS "/etc/debian_version") # is this a debian system ?
-        if(CMAKE_LIBRARY_ARCHITECTURE)
-            list(APPEND _system_lib_dirs "/lib/${CMAKE_LIBRARY_ARCHITECTURE}"
-                                         "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}")
-        endif()
-    endif()
+    __AddInstallRPATHSupport_get_system_lib_dirs(_system_lib_dirs)
+
     # This is relative RPATH for libraries built in the same project
     foreach(lib_dir ${_ARS_LIB_DIRS})
       list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
       if("${isSystemDir}" STREQUAL "-1")
         foreach(bin_dir ${_ARS_LIB_DIRS} ${_ARS_BIN_DIRS})
-          file(RELATIVE_PATH _rel_path ${bin_dir} ${lib_dir})
-          if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-            list(APPEND CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
-          else()
-            list(APPEND CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
-          endif()
+          __AddInstallRPATHSupport_append_relative_rpath(CMAKE_INSTALL_RPATH ${bin_dir} ${lib_dir})
         endforeach()
       endif()
     endforeach()
@@ -160,6 +190,48 @@ function(ADD_INSTALL_RPATH_SUPPORT)
     # which point to directories outside the build tree to the install RPATH
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH ${_ARS_USE_LINK_PATH} PARENT_SCOPE)
 
+  endif()
+
+endfunction()
+
+
+function(TARGET_APPEND_INSTALL_RPATH _target)
+  set(_options )
+  set(_oneValueArgs INSTALL_DESTINATION)
+  set(_multiValueArgs LIB_DIRS
+                      DEPENDS)
+
+  if (CMAKE_SKIP_RPATH OR (CMAKE_SKIP_INSTALL_RPATH AND CMAKE_SKIP_BUILD_RPATH))
+    return()
+  endif()
+
+  cmake_parse_arguments(_ARS "${_options}"
+                             "${_oneValueArgs}"
+                             "${_multiValueArgs}"
+                             "${ARGN}")
+
+  set(_rpath_available 1)
+  if(DEFINED _ARS_DEPENDS)
+    foreach(_dep ${_ARS_DEPENDS})
+      string(REGEX REPLACE " +" ";" _dep "${_dep}")
+      if(NOT (${_dep}))
+        set(_rpath_available 0)
+      endif()
+    endforeach()
+  endif()
+
+  if(_rpath_available)
+
+    __AddInstallRPATHSupport_get_system_lib_dirs(_system_lib_dirs)
+
+    get_target_property(_current_rpath ${_target} INSTALL_RPATH)
+    foreach(lib_dir ${_ARS_LIB_DIRS})
+      list(FIND _system_lib_dirs "${lib_dir}" isSystemDir)
+      if("${isSystemDir}" STREQUAL "-1")
+        __AddInstallRPATHSupport_append_relative_rpath(_current_rpath ${_ARS_INSTALL_DESTINATION} ${lib_dir})
+      endif()
+    endforeach()
+    set_target_properties(${_target} PROPERTIES INSTALL_RPATH "${_current_rpath}")
   endif()
 
 endfunction()

--- a/tests/RunCMake/AddInstallRPATHSupport/AddInstallRPATHSupport_target_append_install_rpath.cmake
+++ b/tests/RunCMake/AddInstallRPATHSupport/AddInstallRPATHSupport_target_append_install_rpath.cmake
@@ -1,0 +1,38 @@
+enable_language(CXX)
+include(AddInstallRPATHSupport)
+
+add_library(foo)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/foo.cpp "void foo() {}\n")
+target_sources(foo PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/foo.cpp)
+
+target_append_install_rpath(foo
+                            INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/lib/foo
+                            LIB_DIRS ${CMAKE_CURRENT_BINARY_DIR}/lib)
+
+get_target_property(foo_rpath foo INSTALL_RPATH)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  string(REGEX REPLACE "@loader_path" "_" foo_rpath_s "${foo_rpath}")
+else()
+  string(REGEX REPLACE "\\$ORIGIN" "_" foo_rpath_s "${foo_rpath}")
+endif()
+
+if (NOT "${foo_rpath_s}" STREQUAL "_/../")
+  message(FATAL_ERROR "Unexpected rpath: ${foo_rpath}")
+endif()
+
+target_append_install_rpath(foo
+                            INSTALL_DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/lib/foo
+                            LIB_DIRS ${CMAKE_CURRENT_BINARY_DIR}/lib/bar)
+
+get_target_property(foo_rpath foo INSTALL_RPATH)
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  string(REGEX REPLACE "@loader_path" "_" foo_rpath_s "${foo_rpath}")
+else()
+  string(REGEX REPLACE "\\$ORIGIN" "_" foo_rpath_s "${foo_rpath}")
+endif()
+
+if (NOT "${foo_rpath_s}" STREQUAL "_/../;_/../bar")
+  message(FATAL_ERROR "Unexpected rpath ${foo_rpath}")
+endif()

--- a/tests/RunCMake/AddInstallRPATHSupport/RunCMakeTest.cmake
+++ b/tests/RunCMake/AddInstallRPATHSupport/RunCMakeTest.cmake
@@ -1,3 +1,4 @@
 include(RunCMake)
 
 run_cmake(AddInstallRPATHSupport_DEPENDS)
+run_cmake(AddInstallRPATHSupport_target_append_install_rpath)


### PR DESCRIPTION
### Modules

#### Generic Modules

* Added the new `target_append_install_rpath` to the `AddInstallRPATHSupport` module, to modify the rpath for a single target.