### PR TITLE
3rd-party: Update Catch2 Git Repository to commit 229cc4823c8cbe67366da8179efc6089dd3893e9

### DIFF
--- a/3rdparty/catch2.cmake
+++ b/3rdparty/catch2.cmake
@@ -17,10 +17,10 @@
 # Catch2 related modules are taken from the Catch2 repository.
 
 set(_files contrib/Catch.cmake                 6f80938187f2fe004db163481ad7b468c6f22ea4
-           contrib/CatchAddTests.cmake         e34403b9ebf165f6e65deddc0f60b280be336b2b
-           contrib/ParseAndAddCatchTests.cmake ec7a0f3acca47bb4e0ae4edcc3b3e053aab27d7d
+           contrib/CatchAddTests.cmake         800eac1ea012cc4bea2f23924cc88ae65d2fbc76
+           contrib/ParseAndAddCatchTests.cmake a63d00cd2b8b21847419ec604e9f3cc1216c4596
            LICENSE.txt                         3cba29011be2b9d59f6204d6fa0a386b1b2dbd90)
-set(_ref v2.8.0)
+set(_ref 229cc4823c8cbe67366da8179efc6089dd3893e9)
 set(_dir "${CMAKE_CURRENT_BINARY_DIR}/catch2")
 _ycm_download(3rdparty-catch2
               "Catch2 (C++ Automated Test Cases in a Header) git repository"

--- a/help/release/0.11.3.rst
+++ b/help/release/0.11.3.rst
@@ -6,3 +6,13 @@ YCM 0.11.3 (UNRELEASED) Release Notes
   .. contents::
 
 Changes made since YCM 0.11.2 include the following.
+
+Modules
+=======
+
+3rd Party
+---------
+
+* Update `Catch2 Git Repository`_ to commit
+  ``229cc4823c8cbe67366da8179efc6089dd3893e9`` (updated :module:`CatchAddTests`
+  and :module:`ParseAndAddCatchTests` modules).


### PR DESCRIPTION
Due to the recent release of CMake 3.18.0, which introduces a regression that breaks all YARP unit tests (see https://gitlab.kitware.com/cmake/cmake/-/issues/21017) we are forced to make an urgent and unplanned release of YCM to include the fixed version of the modules imported from Catch2.
