### PR TITLE
3rd-party: Update Catch2 Git Repository to commit de3a208e167c6baee6e8dc46f2c0466b311324c2

### DIFF
--- a/3rdparty/catch2.cmake
+++ b/3rdparty/catch2.cmake
@@ -18,9 +18,9 @@
 
 set(_files contrib/Catch.cmake                 6f80938187f2fe004db163481ad7b468c6f22ea4
            contrib/CatchAddTests.cmake         800eac1ea012cc4bea2f23924cc88ae65d2fbc76
-           contrib/ParseAndAddCatchTests.cmake a63d00cd2b8b21847419ec604e9f3cc1216c4596
+           contrib/ParseAndAddCatchTests.cmake 7ae77456d2e7a24021e38c4af1c16068ed65ef90
            LICENSE.txt                         3cba29011be2b9d59f6204d6fa0a386b1b2dbd90)
-set(_ref 229cc4823c8cbe67366da8179efc6089dd3893e9)
+set(_ref de3a208e167c6baee6e8dc46f2c0466b311324c2)
 set(_dir "${CMAKE_CURRENT_BINARY_DIR}/catch2")
 _ycm_download(3rdparty-catch2
               "Catch2 (C++ Automated Test Cases in a Header) git repository"

--- a/help/release/0.11.4.rst
+++ b/help/release/0.11.4.rst
@@ -6,3 +6,15 @@ YCM 0.11.4 (UNRELEASED) Release Notes
   .. contents::
 
 Changes made since YCM 0.11.3 include the following.
+
+Modules
+=======
+
+3rd Party
+---------
+
+* Update `Catch2 Git Repository`_ to commit
+  ``de3a208e167c6baee6e8dc46f2c0466b311324c2`` (updated
+  :module:`ParseAndAddCatchTests` module). This fixes the issues with
+  :module:`ParseAndAddCatchTests` tests and CMake 3.18.1 (see
+  :cmake-issue:`21017`).


### PR DESCRIPTION
This fixes the issue with tests in CMake 3.18.1