### PR TITLE
PortAudio: support for imported targets

### DIFF
--- a/find-modules/FindPortAudio.cmake
+++ b/find-modules/FindPortAudio.cmake
@@ -28,40 +28,55 @@
 include(StandardFindModule)
 include(FindPackageHandleStandardArgs)
 
-standard_find_module(PortAudio portaudio-2.0)
+find_package(portaudio CONFIG QUIET)
+if(portaudio_FOUND)
+  set(PortAudio_LIBRARIES portaudio)
+  set(PortAudio_INCLUDE_DIR "")
+  set(PortAudio_INCLUDE_DIRS "")
+  find_package_handle_standard_args(PortAudio DEFAULT_MSG PortAudio_LIBRARIES)
+else()
+  standard_find_module(PortAudio portaudio-2.0)
 
-if(NOT PortAudio_FOUND)
-  if(WIN32)
-    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-      set(_suffix "x86")
-    else()
-      set(_suffix "x64")
-    endif()
+  if(NOT PortAudio_FOUND)
+    # If this is not found via usual means, fallback 
+    # on modern config of unreleased portaudio
+    find_package(portaudio CONFIG QUIET)
+    if(TARGET portaudio)
+      set(PortAudio_LIBRARIES portaudio)
+      set(PortAudio_INCLUDE_DIR "")
+      set(PortAudio_INCLUDE_DIRS "")
+      find_package_handle_standard_args(PortAudio DEFAULT_MSG PortAudio_LIBRARIES)
+    elseif(WIN32)
+      if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(_suffix "x86")
+      else()
+        set(_suffix "x64")
+      endif()
  
-    find_library(PortAudio_LIBRARY_RELEASE
-                 NAMES portaudio_${_suffix}
-                       portaudio
-                 PATHS "C:/portaudio/build/msvc/Debug_${_suffix}")
-    mark_as_advanced(PortAudio_LIBRARY_RELEASE)
+      find_library(PortAudio_LIBRARY_RELEASE
+                   NAMES portaudio_${_suffix}
+                         portaudio
+                   PATHS "C:/portaudio/build/msvc/Debug_${_suffix}")
+      mark_as_advanced(PortAudio_LIBRARY_RELEASE)
 
-    find_library(PortAudio_LIBRARY_DEBUG
-                 NAMES portaudio_${_suffix}
-                       portaudio
-                 PATHS "C:/portaudio/build/msvc/Debug_${_suffix}")
-    mark_as_advanced(PortAudio_LIBRARY_DEBUG)
+      find_library(PortAudio_LIBRARY_DEBUG
+                   NAMES portaudio_${_suffix}
+                         portaudio
+                   PATHS "C:/portaudio/build/msvc/Debug_${_suffix}")
+      mark_as_advanced(PortAudio_LIBRARY_DEBUG)
 
-    include(SelectLibraryConfigurations)
-    select_library_configurations(PortAudio)
+      include(SelectLibraryConfigurations)
+      select_library_configurations(PortAudio)
 
-    find_path(PortAudio_INCLUDE_DIR portaudio.h C:/portaudio/include)
-    mark_as_advanced(PortAudio_INCLUDE_DIR)
+      find_path(PortAudio_INCLUDE_DIR portaudio.h C:/portaudio/include)
+      mark_as_advanced(PortAudio_INCLUDE_DIR)
 
-    set(PortAudio_LIBRARIES ${PortAudio_LIBRARY})
-    set(PortAudio_INCLUDE_DIRS ${PortAudio_INCLUDE_DIR})
-
-    find_package_handle_standard_args(PortAudio DEFAULT_MSG PortAudio_LIBRARIES)
-    set(PortAudio_FOUND ${PORTAUDIO_FOUND})
-
+      set(PortAudio_LIBRARIES ${PortAudio_LIBRARY})
+      set(PortAudio_INCLUDE_DIRS ${PortAudio_INCLUDE_DIR})
+    
+      find_package_handle_standard_args(PortAudio DEFAULT_MSG PortAudio_LIBRARIES)
+      set(PortAudio_FOUND ${PORTAUDIO_FOUND})
+    endif()
   endif()
 endif()
 

--- a/find-modules/FindPortAudio.cmake
+++ b/find-modules/FindPortAudio.cmake
@@ -38,15 +38,7 @@ else()
   standard_find_module(PortAudio portaudio-2.0)
 
   if(NOT PortAudio_FOUND)
-    # If this is not found via usual means, fallback 
-    # on modern config of unreleased portaudio
-    find_package(portaudio CONFIG QUIET)
-    if(TARGET portaudio)
-      set(PortAudio_LIBRARIES portaudio)
-      set(PortAudio_INCLUDE_DIR "")
-      set(PortAudio_INCLUDE_DIRS "")
-      find_package_handle_standard_args(PortAudio DEFAULT_MSG PortAudio_LIBRARIES)
-    elseif(WIN32)
+    if(WIN32)
       if(CMAKE_SIZEOF_VOID_P EQUAL 4)
         set(_suffix "x86")
       else()


### PR DESCRIPTION
If a modern (unreleased but already available as 2020 in vcpkg) portaudio that installs CMake imported targets is available, use that in FindPortAudio .

Fix https://github.com/robotology/yarp/issues/2117 .