### PR TITLE
Fix FindIPOPT to work with IPOPT 3.13 and conda

### DIFF
--- a/find-modules/FindIPOPT.cmake
+++ b/find-modules/FindIPOPT.cmake
@@ -82,7 +82,7 @@ if(NOT WIN32)
       set(IPOPT_DIR /usr            CACHE PATH "Path to IPOPT build directory")
     endif()
 
-    find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp PATH_SUFFIXES coin PATHS ${IPOPT_DIR}/include/coin)
+    find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp PATH_SUFFIXES coin coin-or PATHS ${IPOPT_DIR}/include/coin)
     
     find_library(IPOPT_LIBRARIES ipopt ${IPOPT_DIR}/lib
                                      ${IPOPT_DIR}/lib/coin)
@@ -128,7 +128,7 @@ else()
 
   set(IPOPT_DIR $ENV{IPOPT_DIR} CACHE PATH "Path to IPOPT build directory")
   
-  find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp PATH_SUFFIXES coin PATHS ${IPOPT_DIR}/include/coin)
+  find_path(IPOPT_INCLUDE_DIRS NAMES IpIpoptApplication.hpp PATH_SUFFIXES coin coin-or PATHS ${IPOPT_DIR}/include/coin)
 
   find_library(IPOPT_IPOPT_LIBRARY_RELEASE libipopt ${IPOPT_DIR}/lib
                                                     ${IPOPT_DIR}/lib/coin)
@@ -207,7 +207,9 @@ else()
         find_library(IPOPT_${_LIB}_LIBRARY_RELEASE ${_lib} ${_IPOPT_IPOPT_LIBRARY_DIR})
         find_library(IPOPT_${_LIB}_LIBRARY_DEBUG ${_lib}d ${_IPOPT_IPOPT_LIBRARY_DIR})
         select_library_configurations(IPOPT_${_LIB})
-        list(APPEND IPOPT_LIBRARIES ${IPOPT_${_LIB}_LIBRARY})
+        if(${IPOPT_${_LIB}_LIBRARY})
+          list(APPEND IPOPT_LIBRARIES ${IPOPT_${_LIB}_LIBRARY})
+        endif()
       endforeach()
     endif()
   endif()

--- a/help/release/0.12.1.rst
+++ b/help/release/0.12.1.rst
@@ -15,3 +15,9 @@ Generic Modules
 
 * The :module:`StandardFindModule` learned to handle -framework
   options passed in the Libs field of pkg-config files.
+
+Find Modules
+------------
+
+* The :module:`FindIPOPT` learned to find IPOPT 3.13 and the
+  binaries installed by the conda-forge IPOPT package.


### PR DESCRIPTION
This PR includes two changes:
* Take into account that header files are not installed in <prefix>/include/coin-or (see https://github.com/coin-or/Ipopt/blob/releases/3.13.0/ChangeLog)
* The ipopt on Windows binary provided by conda are compiled by MSVC and Flang, so they do not ship with all the ifortran related libraries. If this libraries are not found, do not add them in IPOPT_LIBRARIES to avoid a failure in `find_package_handle_standard_args` (see https://github.com/conda-forge/ipopt-feedstock/pull/47)