### PR TITLE
Fix FindAssimp on Windows

### DIFF
--- a/find-modules/Findassimp.cmake
+++ b/find-modules/Findassimp.cmake
@@ -56,6 +56,12 @@ This module defines the following variables:
 
 #]=======================================================================]
 
+find_package(assimp NO_MODULE QUIET)
+if(assimp_FOUND)
+  find_package_handle_standard_args(assimp CONFIG_MODE)
+  return()
+endif()
+
 set(ASSIMP_SHARED_LIBRARY_NAME)
 set(ASSIMP_SHARED_LIBRARY_NAME_DEBUG)
 

--- a/help/release/0.12.2.rst
+++ b/help/release/0.12.2.rst
@@ -22,3 +22,9 @@ Superbuild Modules
 * Fixed a bug in :module:`YCMEPHelper` that prevented from opening the CMake
   cache editor when the corresponding target was used in development mode, e.g.
   ``<project_name>-edit_cache``.
+
+Find Modules
+------------
+
+* The :module:`Findassimp` learned to first check if
+  an assimp CMake config is present in the system.


### PR DESCRIPTION
The logic of FindAssimp is broken on Windows, as on VS2019 it looks only for assimp libraries compiled under VS2019 (i.e. with the -vc150 suffix) but VS2019 is perfectly compatible with assimp libraries compiled with VS2015 or VS2017. This was causing the problem reported in https://github.com/robotology/idyntree/pull/832#issuecomment-779671792 .

The fix is to first look for an assimp CMake config file in the system, and only do the manual search if this is not found.