### PR TITLE
Fix edit_cache targets in development mode

### DIFF
--- a/help/release/0.12.2.rst
+++ b/help/release/0.12.2.rst
@@ -15,3 +15,10 @@ Modules
 ---------
 
 * Update `Catch2 Git Repository`_ to tag ``v2.13.4``.
+
+Superbuild Modules
+------------------
+
+* Fixed a bug in :module:`YCMEPHelper` that prevented from opening the CMake
+  cache editor when the corresponding target was used in development mode, e.g.
+  ``<project_name>-edit_cache``.

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -619,11 +619,12 @@ function(_YCM_EP_ADD_EDIT_CACHE_STEP _name)
   _ep_get_configure_command_id(${_name} _${_name}_configure_command_id)
   if(_${_name}_configure_command_id STREQUAL "cmake")
 
+    get_property(_source_dir TARGET ${_name} PROPERTY _EP_SOURCE_DIR)
     get_property(_source_subdir TARGET ${_name} PROPERTY _EP_SOURCE_SUBDIR)
     get_property(_binary_dir TARGET ${_name} PROPERTY _EP_BINARY_DIR)
 
     ExternalProject_Add_Step(${_name} edit_cache
-                             COMMAND ${CMAKE_EDIT_COMMAND} -H${_source_subdir} -B${_binary_dir}
+                             COMMAND ${CMAKE_EDIT_COMMAND} -H${_source_dir}${_source_subdir} -B${_binary_dir}
                              WORKING_DIRECTORY ${_binary_dir}
                              DEPENDEES configure
                              EXCLUDE_FROM_MAIN 1


### PR DESCRIPTION
I have noticed that upon enabling development mode on a superbuild subproject (either `YCM_EP_DEVEL_MODE_<project_name>` or `YCM_EP_MAINTAINER_MODE` set to `ON`, where `<project_name>` is orchestrated by YCM/ExternalProject), a specific target (e.g. `<project_name>-edit_cache`) is generated which opens the CMake cache editor, i.e. `ccmake`. It didn't work for me, though.

Then, I saw something like this in `build/CMakeFiles/<project_name>-edit_cache.dir/build.make` (real excerpt from generated Makefile by https://github.com/roboticslab-uc3m/asibot-main superbuild):

```make
external/ROBOTICSLAB_KINEMATICS_DYNAMICS/CMakeFiles/YCMStamp/ROBOTICSLAB_KINEMATICS_DYNAMICS-edit_cache: external/ROBOTICSLAB_KINEMATICS_DYNAMICS/CMakeFiles/YCMStamp/ROBOTICSLAB_KINEMATICS_DYNAMICS-configure
	@$(CMAKE_COMMAND) -E cmake_echo_color --switch=$(COLOR) --blue --bold --progress-dir=/home/bartek/wingit/asibot-main/build/CMakeFiles --progress-num=$(CMAKE_PROGRESS_1) "Running CMake cache editor for ROBOTICSLAB_KINEMATICS_DYNAMICS..."
	cd /home/bartek/wingit/asibot-main/build/external/ROBOTICSLAB_KINEMATICS_DYNAMICS && /usr/bin/ccmake -H -B/home/bartek/wingit/asibot-main/build/external/ROBOTICSLAB_KINEMATICS_DYNAMICS
```

The problem boils down to:

```
/usr/bin/ccmake -H -B<path_to_build_dir>
```

Cause: no source dir provided to the `-H` option since variable expansion failed. This patch aims to fix it while still accounting for the source subdir suffix. Tested on CMake 3.16.3 (Ubuntu 20.04).