### PR TITLE
Fix Findassimp.cmake in Ubuntu 20.04 and 18.04

### DIFF
--- a/find-modules/Findassimp.cmake
+++ b/find-modules/Findassimp.cmake
@@ -58,8 +58,12 @@ This module defines the following variables:
 
 find_package(assimp NO_MODULE QUIET)
 if(assimp_FOUND)
-  # Workaround for malformed assimp config CMake files in Ubuntu 20.04 
-  # see https://github.com/robotology/idyntree/issues/693 for more details
+  # Workaround for malformed assimp config CMake files in Ubuntu 18.04 and 20.04 
+  # see https://github.com/robotology/idyntree/issues/693 and
+  # https://github.com/robotology/ycm/issues/224 for more details
+  if(DEFINED ASSIMP_INCLUDE_DIRS)
+    string(REPLACE "/usr/lib/include" "/usr/include" ASSIMP_INCLUDE_DIRS "${ASSIMP_INCLUDE_DIRS}")
+  endif()
   if(TARGET assimp::assimp)
     get_property(assimp_INTERFACE_INCLUDE_DIRECTORIES
                  TARGET assimp::assimp

--- a/find-modules/Findassimp.cmake
+++ b/find-modules/Findassimp.cmake
@@ -58,6 +58,25 @@ This module defines the following variables:
 
 find_package(assimp NO_MODULE QUIET)
 if(assimp_FOUND)
+  # Workaround for malformed assimp config CMake files in Ubuntu 20.04 
+  # see https://github.com/robotology/idyntree/issues/693 for more details
+  if(TARGET assimp::assimp)
+    get_property(assimp_INTERFACE_INCLUDE_DIRECTORIES
+                 TARGET assimp::assimp
+                 PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+    if(assimp_INTERFACE_INCLUDE_DIRECTORIES MATCHES "/usr/lib/include")
+      string(REPLACE "/usr/lib/include" "/usr/include" assimp_INTERFACE_INCLUDE_DIRECTORIES "${assimp_INTERFACE_INCLUDE_DIRECTORIES}")
+      set_property(TARGET assimp::assimp
+                   PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                   "${assimp_INTERFACE_INCLUDE_DIRECTORIES}")
+      get_property(assimp_LOCATION_RELEASE
+                   TARGET assimp::assimp
+                   PROPERTY LOCATION_RELEASE)
+      set_property(TARGET assimp::assimp
+                   PROPERTY IMPORTED_LOCATION
+                   "${assimp_LOCATION_RELEASE}")
+    endif()
+  endif()
   find_package_handle_standard_args(assimp CONFIG_MODE)
   return()
 endif()


### PR DESCRIPTION
Unfortunately what discussed in https://github.com/robotology/ycm/pull/371#issuecomment-780720827 turned out to be true. 

In particular, if I understood correctly (still needs to be confirmed) @randaz81 is having problem in https://github.com/robotology/cer due to the specific order of `find_package(YCM)`  and `find_package(gazebo)` calls (gazebo's CMake config file calls DART's CMake config file that calls `find_package(assimp)` , whose behavior change depending of weather `find_package(YCM)` was called or not). While this could be probably fixed by moving `find_package(gazebo)`  before `find_package(YCM)`, this PR should provide a more robust fix by having a logic to detect the malformed assimp configuration file of Ubuntu 20.04 and fixing it. 

cc @randaz81 if you could test this it would be great.