### PR TITLE
Import FindUDev.cmake from ECM repository

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -28,6 +28,7 @@ if(NOT YCM_NO_3RDPARTY OR YCM_MAINTAINER_MODE)
   include("${CMAKE_CURRENT_LIST_DIR}/qgv.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/cmrc.cmake")
   include("${CMAKE_CURRENT_LIST_DIR}/uselatex.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/ecm.cmake")
 
   # Print a warning if we are overriding some module from CMake
   file(GLOB_RECURSE _modules

--- a/3rdparty/ecm.cmake
+++ b/3rdparty/ecm.cmake
@@ -1,0 +1,46 @@
+#=============================================================================
+# Copyright 2013-2021 Istituto Italiano di Tecnologia (IIT)
+#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of YCM, substitute the full
+#  License text for the above reference.)
+
+
+##############################################################################
+# FindUDev.cmake is taken from the ECM repository.
+
+set(_files COPYING-CMAKE-SCRIPTS       ff3ed70db4739b3c6747c7f624fe2bad70802987
+           find-modules/FindUDev.cmake 10bfe244e8f2c4d85338563a0057656093fb0d08)
+set(_ref v5.79.0)
+set(_dir "${CMAKE_CURRENT_BINARY_DIR}/ecm")
+
+_ycm_download(3rdparty-ecm
+              "KDE Extra CMake Modules git repository"
+              "https://invent.kde.org/frameworks/extra-cmake-modules/-/raw/<REF>/<FILE>"
+              ${_ref} "${_dir}" "${_files}")
+file(WRITE "${_dir}/README.ECM"
+"Some of the files in this folder and its subfolder come from the ECM git
+repository (ref ${_ref}):
+
+  https://invent.kde.org/frameworks/extra-cmake-modules
+
+Redistribution and use is allowed according to the terms of the 3-clause
+BSD license. See accompanying file COPYING.ECM for details.
+")
+
+_ycm_install(3rdparty-ecm FILES "${_dir}/find-modules/FindUDev.cmake"
+                          DESTINATION "${YCM_INSTALL_MODULE_DIR}/3rdparty")
+
+_ycm_install(3rdparty-ecm FILES "${_dir}/COPYING-CMAKE-SCRIPTS"
+                          DESTINATION "${YCM_INSTALL_MODULE_DIR}/3rdparty"
+                          RENAME COPYING.ECM)
+
+_ycm_install(3rdparty-ecm FILES "${_dir}/README.ECM"
+                          DESTINATION "${YCM_INSTALL_MODULE_DIR}/3rdparty")

--- a/docs/conf.py.in
+++ b/docs/conf.py.in
@@ -116,6 +116,7 @@ rst_epilog = """
 .. _`qgv Git Repository`: https://github.com/nbergont/qgv/
 .. _`CMakeRC Git Repository`: https://github.com/vector-of-bool/cmrc/
 .. _`UseLATEX Git Repository`: https://gitlab.kitware.com/kmorel/UseLATEX/
+.. _`ECM Git Repository`: https://invent.kde.org/frameworks/extra-cmake-modules
 .. _`10.1109/IRC.2018.00014`: https://doi.org/10.1109/IRC.2018.00014
 .. _`10.1142/S1793351X19400087`: https://doi.org/10.1142/S1793351X19400087
 

--- a/help/release/0.13.0.rst
+++ b/help/release/0.13.0.rst
@@ -16,3 +16,13 @@ Deprecated Modules
 * The ``FindGLUT`` module in YCM is deprecated. The one from CMake is now used.
   The ``GLUT_INCLUDE_DIRS`` is therefore deprecated, the target ``GLUT::GLUT``
   should be used instead.
+
+
+Modules
+=======
+
+3rd Party
+---------
+
+
+* Imported :module:`FindUDev` module from `ECM Git Repository`_ +


### PR DESCRIPTION
I'm not 100% sure that this is how we should handle this, since we could just add a dependency on ECM.
Anyway, ECM brings some extra build dependencies (Qt5, Python3), therefore for now I suggest to handle it in this way.


CC @triccyx 