### PR TITLE
Update 'VTK Git Repository' to tag v9.0.1

### DIFF
--- a/3rdparty/vtk.cmake
+++ b/3rdparty/vtk.cmake
@@ -17,8 +17,8 @@
 # FindFFMPEG.cmake is taken from the VTK repository
 
 set(_files Copyright.txt                       73e1eb91dcdfcedf106ced4e67bc691614f0a3b3
-           CMake/FindFFMPEG.cmake              7a979800a51b0fd7af24be3ee88ea37309294695)
-set(_ref v8.1.1)
+           CMake/FindFFMPEG.cmake              08ef5c25b33a4ee3cd4d65027412d2ef60c46281)
+set(_ref v9.0.1)
 set(_dir "${CMAKE_CURRENT_BINARY_DIR}/vtk")
 
 _ycm_download(3rdparty-vtk

--- a/help/release/0.13.0.rst
+++ b/help/release/0.13.0.rst
@@ -26,3 +26,6 @@ Modules
 
 
 * Imported :module:`FindUDev` module from `ECM Git Repository`_ +
+* Update `VTK Git Repository`_ to tag ``v9.0.1``.
+  The :module:`FindFFMPEG` module now offers targets, but it requires to specify
+  the `COMPONENTS` to the `find_package(FFMPEG)` calls.


### PR DESCRIPTION
The FindFFMPEG module now offers targets, but it requires to specify
the COMPONENTS to the find_package(FFMPEG) calls.

CC-Issue: robotology/yarp#2530
CC-Issue: robotology/yarp#2529