### PR TITLE
 Package `ycm` with setuptools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default owners
+*       @drdanz
+
+# Python resources
+tools/pip/ @dferigo

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,139 @@
+name: Python CI/CD
+
+on:
+  push:
+    branches: ['**']
+    tags-ignore: ['**']
+  pull_request:
+  release:
+    types:
+      - published
+
+jobs:
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-20.04
+
+    steps:
+
+      - uses: actions/checkout@master
+      - run: git fetch --prune --unshallow
+
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install pypa/build
+        run: pip install build
+
+      - name: Build sdist
+        run: python -m build --sdist --outdir dist/ tools/pip
+
+      - name: Install sdist
+        run: pip -v install --use-feature=in-tree-build dist/ycm_cmake_modules-*.tar.gz
+
+      - name: Test import
+        run: python -c 'import ycm_cmake_modules'
+
+      - name: Remove external wheels
+        run: find dist/ -type f -not -name 'ycm_cmake_modules-*' -delete -print
+
+      - name: Inspect dist folder
+        run: ls -lah dist/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: dist/*.tar.gz
+
+  build_wheel:
+    name: Build wheel
+    runs-on: ubuntu-20.04
+
+    steps:
+
+      - uses: actions/checkout@master
+      - run: git fetch --prune --unshallow
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install pypa/build
+        run: pip install build
+
+      - name: Build wheel
+        run: python -m build --wheel --outdir dist/ tools/pip
+
+      - name: Remove external wheels
+        run: find dist/ -type f -not -name 'ycm_cmake_modules-*' -delete -print
+
+      # setuptools thinks that the package is OS-dependent because it uses a
+      # build extension, but instead it does not contain any compiled code.
+      - name: Rename wheel
+        run: |
+          sudo apt update
+          sudo apt install -y rename
+          find . -type f -name "*.whl" -exec rename -v "s/cp(\d)(\d)-cp(\d)(\d)-linux_x86_64/py3-none-any/g" {} +
+
+      - name: Install wheel
+        run: pip install dist/ycm_cmake_modules-*.whl
+
+      - name: Test import
+        run: python -c 'import ycm_cmake_modules'
+
+      - name: Inspect dist folder
+        run: ls -lah dist/
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ./dist/*.whl
+
+  upload_pypi:
+    needs:
+      - build_sdist
+      - build_wheel
+    runs-on: ubuntu-latest
+    # Branch master produces pre-releases.
+    # GitHub Releases 'vX.Y.Z' produce stable releases.
+
+    steps:
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Inspect dist folder
+        run: ls -lah dist/
+
+      # Validate the tag accordingly to PEP440
+      # From https://stackoverflow.com/a/37972030/12150968
+      - name: Check PEP440 compliance
+        if: github.event_name == 'release'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y source-highlight
+          last_tag_with_v="$(git describe --abbrev=0 --tags)"
+          last_tag=${last_tag_with_v#v}
+          rel_regexp='^(\d+!)?(\d+)(\.\d+)+([\.\-\_])?((a(lpha)?|b(eta)?|c|r(c|ev)?|pre(view)?)\d*)?(\.?(post|dev)\d*)?$'
+          echo ""
+          echo $last_tag
+          echo ""
+          check-regexp ${rel_regexp} ${last_tag}
+          match=$(check-regexp ${rel_regexp} ${last_tag} | grep matches | cut -d ' ' -f 5)
+          test $match -eq 1 && true
+
+      - uses: pypa/gh-action-pypi-publish@master
+        if: |
+          github.repository == 'robotology/ycm' &&
+          ((github.event_name == 'release' && github.event.action == 'published') ||
+           (github.event_name == 'push' && github.ref == 'refs/heads/master'))
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip_existing: true

--- a/tools/pip/README.md
+++ b/tools/pip/README.md
@@ -1,0 +1,40 @@
+# ycm-cmake-modules
+
+Extra CMake Modules for YARP and friends.
+
+## Installation
+
+### From PyPI
+
+Run the following command to install YCM from PyPI:
+
+```bash
+pip install ycm_cmake_modules
+```
+
+### From sources
+
+Run the following command to install YCM from the master branch:
+
+```bash
+pip install "git+https://github.com/robotology/ycm@master#egg=ycm_cmake_modules&subdirectory=tools/pip"
+```
+
+### From cloned repository
+
+Run the following command to install YCM from the root of a cloned repository:
+
+```bash
+pip install tools/pip
+```
+
+Note: if you use `pip < 21.3` you also need to pass `--use-feature=in-tree-build`.
+
+### Create source and wheel distributions
+
+Run the following to create the source distribution (sdist) and the binary distribution (wheel):
+
+```bash
+pip install build
+python -m build -o dist/ tools/pip
+```

--- a/tools/pip/pyproject.toml
+++ b/tools/pip/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "wheel",
+    "setuptools>=45",
+    "setuptools_scm[toml]>=6.0",
+    "cmake-build-extension>=0.3.2",
+    "cmake>=3.12",
+    "ninja",
+]
+
+[tool.setuptools_scm]
+root = "../.."
+local_scheme = "dirty-tag"

--- a/tools/pip/setup.cfg
+++ b/tools/pip/setup.cfg
@@ -1,0 +1,44 @@
+[metadata]
+name = ycm_cmake_modules
+description = Extra CMake Modules for YARP and friends.
+long_description = file: README.md; charset=UTF-8
+long_description_content_type = text/markdown
+author = Diego Ferigo
+author_email = dgferigo@gmail.com
+license = BSD
+platforms = any
+url = http://robotology.github.io/ycm
+
+project_urls =
+    Tracker = https://github.com/robotology/ycm/issues
+    Documentation = http://robotology.github.io/ycm
+    Source = https://github.com/robotology/ycm
+
+keywords =
+    cmake
+    cmake-modules
+    cmake-resources
+    build-tool
+    build-system
+    superbuild
+    yarp
+    robotics
+
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Operating System :: POSIX :: Linux
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Operating System :: OS Independent
+    Framework :: Robot Framework
+    Intended Audience :: Science/Research
+    Intended Audience :: Developers
+    Intended Audience :: Education
+    Topic :: Software Development :: Build Tools
+    Topic :: Software Development :: Code Generators
+    Topic :: System :: Archiving :: Packaging
+    License :: OSI Approved :: BSD License
+
+[options]
+zip_safe = False
+python_requires = >=3.0

--- a/tools/pip/setup.py
+++ b/tools/pip/setup.py
@@ -1,0 +1,39 @@
+import os
+from pathlib import Path
+
+import cmake_build_extension
+from setuptools import setup
+
+if (Path(".") / "CMakeLists.txt").exists():
+    # Install from sdist
+    source_dir = str(Path(".").absolute())
+else:
+    # Install from sources or build wheel
+    source_dir = str(Path(".").absolute().parent.parent)
+
+if "CIBUILDWHEEL" in os.environ and os.environ["CIBUILDWHEEL"] == "1":
+    CIBW_CMAKE_OPTIONS = ["-DCMAKE_INSTALL_LIBDIR=lib"]
+else:
+    CIBW_CMAKE_OPTIONS = []
+
+
+setup(
+    cmdclass=dict(
+        build_ext=cmake_build_extension.BuildExtension,
+        sdist=cmake_build_extension.GitSdistFolder,
+    ),
+    ext_modules=[
+        cmake_build_extension.CMakeExtension(
+            name="CMakeProject",
+            install_prefix="ycm_cmake_modules",
+            disable_editable=True,
+            write_top_level_init="",
+            source_dir=source_dir,
+            cmake_configure_options=[
+                "-DBUILD_TESTING:BOOL=OFF",
+                "-DYCM_NO_DEPRECATED:BOOL=ON",
+            ]
+            + CIBW_CMAKE_OPTIONS,
+        ),
+    ],
+)


### PR DESCRIPTION
Twin PR of https://github.com/robotology/yarp/pull/2573.

- Also the `ycm` package name [is already taken](https://pypi.org/project/ycm/) in PyPI. In this case, I can try to submit a PEP541 request in [pypa/pypi-support](https://github.com/pypa/pypi-support) to get the ownership. (done in https://github.com/pypa/pypi-support/issues/1096)
- For ycm the github workflow and wheel generation is much simpler since it does not contain any C++ code, and the wheel could be shared for all OSs.