### PR TITLE
3rd party: Import the CMakeRC module from robotology-dependencies

### DIFF
--- a/3rdparty/cmrc.cmake
+++ b/3rdparty/cmrc.cmake
@@ -4,14 +4,19 @@
 ##############################################################################
 # CMakeRC.cmake is taken from the CMakeRC repository.
 
-set(_files CMakeRC.cmake  e8c69652bfd87abb1d4ac8cb977ec2b5050fdec4
+set(_files CMakeRC.cmake  8eceaebb7b1bb703695b8bdf84c0fc111bc66de5
            LICENSE.txt    053245749bccc40304ec4d9d0a47aea0b1c9f8f6)
-set(_ref 966a1a717715f4e57fb1de00f589dea1001b5ae6)
+set(_ref 1bf6fe0b1299068561fac87bfba93980511bbe6a)
 set(_dir "${CMAKE_CURRENT_BINARY_DIR}/cmrc")
+
+#_ycm_download(3rdparty-cmrc
+              #"CMakeRC (A Standalone CMake-Based C++ Resource Compiler) git repository"
+              #"https://raw.githubusercontent.com/vector-of-bool/cmrc/<REF>/<FILE>"
+              #${_ref} "${_dir}" "${_files}")
 
 _ycm_download(3rdparty-cmrc
               "CMakeRC (A Standalone CMake-Based C++ Resource Compiler) git repository"
-              "https://raw.githubusercontent.com/vector-of-bool/cmrc/<REF>/<FILE>"
+              "https://raw.githubusercontent.com/robotology-dependencies/cmrc/<REF>/<FILE>"
               ${_ref} "${_dir}" "${_files}")
 
 file(WRITE "${_dir}/README.CMakeRC"

--- a/help/release/0.13.0.rst
+++ b/help/release/0.13.0.rst
@@ -29,3 +29,5 @@ Modules
 * Update `VTK Git Repository`_ to tag ``v9.0.1``.
   The :module:`FindFFMPEG` module now offers targets, but it requires to specify
   the `COMPONENTS` to the `find_package(FFMPEG)` calls.
+* The :module:`CMakeRC` module is now imported from `robotology-dependencies`
+  fork in order to be able to produce `OBJECT` libraries.


### PR DESCRIPTION
The module is now able to produce `OBJECT` libraries

See also https://github.com/robotology/yarp/pull/2637