### PR TITLE
3rdparty/cmrc: Retrieve latest version from original repository

### DIFF
--- a/3rdparty/cmrc.cmake
+++ b/3rdparty/cmrc.cmake
@@ -4,19 +4,14 @@
 ##############################################################################
 # CMakeRC.cmake is taken from the CMakeRC repository.
 
-set(_files CMakeRC.cmake  8eceaebb7b1bb703695b8bdf84c0fc111bc66de5
+set(_files CMakeRC.cmake  15109e38dddefce15028a0d0563557b2dc72446a
            LICENSE.txt    053245749bccc40304ec4d9d0a47aea0b1c9f8f6)
-set(_ref 1bf6fe0b1299068561fac87bfba93980511bbe6a)
+set(_ref f26f6e35a859b0ba28818dbcc0ed9b3880881cf4)
 set(_dir "${CMAKE_CURRENT_BINARY_DIR}/cmrc")
-
-#_ycm_download(3rdparty-cmrc
-              #"CMakeRC (A Standalone CMake-Based C++ Resource Compiler) git repository"
-              #"https://raw.githubusercontent.com/vector-of-bool/cmrc/<REF>/<FILE>"
-              #${_ref} "${_dir}" "${_files}")
 
 _ycm_download(3rdparty-cmrc
               "CMakeRC (A Standalone CMake-Based C++ Resource Compiler) git repository"
-              "https://raw.githubusercontent.com/robotology-dependencies/cmrc/<REF>/<FILE>"
+              "https://raw.githubusercontent.com/vector-of-bool/cmrc/<REF>/<FILE>"
               ${_ref} "${_dir}" "${_files}")
 
 file(WRITE "${_dir}/README.CMakeRC"

--- a/help/release/0.13.1.rst
+++ b/help/release/0.13.1.rst
@@ -6,3 +6,12 @@ YCM 0.13.1 (UNRELEASED) Release Notes
   .. contents::
 
 Changes made since YCM 0.13.0 include the following.
+
+Modules
+=======
+
+3rd Party
+---------
+
+* The :module:`CMakeRC` module is imported again from the official repository,
+  and it no longer prints the debug message.


### PR DESCRIPTION
Modules
=======

3rd Party
---------

* The :module:`CMakeRC` module is imported again from the official repository,
  and it no longer prints the debug message.
