### PR TITLE
FindGraphviz: Fix finding graphviz not installed in system directories

### DIFF
--- a/3rdparty/qgv/FindGraphviz.cmake
+++ b/3rdparty/qgv/FindGraphviz.cmake
@@ -88,6 +88,7 @@ find_path(Graphviz_INCLUDE_DIR
                 /usr/include/graphviz
                 /usr/local/include
                 /usr/local/include/graphviz
+          PATH_SUFFIXES graphviz
           HINTS ${Graphviz_PKG_INCLUDE_DIR})
 mark_as_advanced(Graphviz_INCLUDE_DIR)
 


### PR DESCRIPTION
When graphviz is not installed in system directories, its headers are installed in a path like:
~~~
<install_prefix>/include/graphviz/cgraph.h
~~~

Before this PR, even if `<install_prefix>` is added to the `CMAKE_PREFIX_PATH`, the snippet of code:
~~~cmake
find_path(Graphviz_INCLUDE_DIR
          NAMES cgraph.h
          PATHS ${Graphviz_POSSIBLE_INCDIRS}
                /usr/include
                /usr/include/graphviz
                /usr/local/include
                /usr/local/include/graphviz
          HINTS ${Graphviz_PKG_INCLUDE_DIR})
~~~

would not find it, and would mark Graphviz as not found. In this PR, we add the `PATH_SUFFIXES` option so that regardless of the installation prefix Graphvix is correctly found. This for example would fix finding Graphviz when it is installed in a conda environment.

While this file is in `3rdparty/qgv`, I opened directly a PR here as the original from which the file was obtained is now archived: https://github.com/nbergont/qgv/ .