### PR TITLE
Switch main mantainer from drdanz to traversaro

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners
-*       @drdanz
+*       @traversaro
 
 # Python resources
 tools/pip/ @dferigo


### PR DESCRIPTION
As discussed on Teams, switch mantainer of YCM from @drdanz to @traversaro . 