### PR TITLE
ExternalProject: Check all possible locations of RepositoryInfo.txt.in file to avoid problem with CMake 3.23 and release YCM 0.13.1

### DIFF
--- a/cmake-next/proposed/ExternalProject.cmake
+++ b/cmake-next/proposed/ExternalProject.cmake
@@ -965,6 +965,14 @@ set(_ep_hash_regex "^(${_ep_hash_algos})=([0-9A-Fa-f]+)$")
 set(_ExternalProject_SELF "${CMAKE_CURRENT_LIST_FILE}")
 get_filename_component(_ExternalProject_SELF_DIR "${_ExternalProject_SELF}" PATH)
 
+# Check location of RepositoryInfo.txt.in
+# Workaround of https://github.com/robotology/robotology-superbuild/issues/1074
+if(EXISTS "${CMAKE_ROOT}/Modules/RepositoryInfo.txt.in")
+  set(_ExternalProject_RepositoryInfo_Location "${CMAKE_ROOT}/Modules/RepositoryInfo.txt.in")
+elseif(EXISTS "${CMAKE_ROOT}/Modules/ExternalProject/RepositoryInfo.txt.in")
+  set(_ExternalProject_RepositoryInfo_Location "${CMAKE_ROOT}/Modules/ExternalProject/RepositoryInfo.txt.in")
+endif()
+
 function(_ep_parse_arguments f name ns args)
   # Transfer the arguments to this function into target properties for the
   # new custom target we just added so that we can set up all the build steps
@@ -2427,7 +2435,7 @@ function(_ep_add_download_command name)
     set(module ${cvs_module})
     set(tag ${cvs_tag})
     configure_file(
-      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
+      "${_ExternalProject_RepositoryInfo_Location}"
       "${stamp_dir}/${name}-cvsinfo.txt"
       @ONLY
       )
@@ -2452,7 +2460,7 @@ function(_ep_add_download_command name)
     set(module)
     set(tag ${svn_revision})
     configure_file(
-      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
+      "${_ExternalProject_RepositoryInfo_Location}"
       "${stamp_dir}/${name}-svninfo.txt"
       @ONLY
       )
@@ -2515,7 +2523,7 @@ function(_ep_add_download_command name)
     set(module)
     set(tag ${git_remote_name})
     configure_file(
-      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
+      "${_ExternalProject_RepositoryInfo_Location}"
       "${stamp_dir}/${name}-gitinfo.txt"
       @ONLY
       )
@@ -2555,7 +2563,7 @@ function(_ep_add_download_command name)
     set(module)
     set(tag)
     configure_file(
-      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
+      "${_ExternalProject_RepositoryInfo_Location}"
       "${stamp_dir}/${name}-hginfo.txt"
       @ONLY
       )
@@ -2593,7 +2601,7 @@ function(_ep_add_download_command name)
     set(module "${url}")
     set(tag "${hash}")
     configure_file(
-      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
+      "${_ExternalProject_RepositoryInfo_Location}"
       "${stamp_dir}/${name}-urlinfo.txt"
       @ONLY
       )

--- a/cmake-next/proposed/ExternalProject.cmake
+++ b/cmake-next/proposed/ExternalProject.cmake
@@ -2427,7 +2427,7 @@ function(_ep_add_download_command name)
     set(module ${cvs_module})
     set(tag ${cvs_tag})
     configure_file(
-      "${CMAKE_ROOT}/Modules/RepositoryInfo.txt.in"
+      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
       "${stamp_dir}/${name}-cvsinfo.txt"
       @ONLY
       )
@@ -2452,7 +2452,7 @@ function(_ep_add_download_command name)
     set(module)
     set(tag ${svn_revision})
     configure_file(
-      "${CMAKE_ROOT}/Modules/RepositoryInfo.txt.in"
+      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
       "${stamp_dir}/${name}-svninfo.txt"
       @ONLY
       )
@@ -2515,7 +2515,7 @@ function(_ep_add_download_command name)
     set(module)
     set(tag ${git_remote_name})
     configure_file(
-      "${CMAKE_ROOT}/Modules/RepositoryInfo.txt.in"
+      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
       "${stamp_dir}/${name}-gitinfo.txt"
       @ONLY
       )
@@ -2555,7 +2555,7 @@ function(_ep_add_download_command name)
     set(module)
     set(tag)
     configure_file(
-      "${CMAKE_ROOT}/Modules/RepositoryInfo.txt.in"
+      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
       "${stamp_dir}/${name}-hginfo.txt"
       @ONLY
       )
@@ -2593,7 +2593,7 @@ function(_ep_add_download_command name)
     set(module "${url}")
     set(tag "${hash}")
     configure_file(
-      "${CMAKE_ROOT}/Modules/RepositoryInfo.txt.in"
+      "${_ExternalProject_SELF_DIR}/RepositoryInfo.txt.in"
       "${stamp_dir}/${name}-urlinfo.txt"
       @ONLY
       )

--- a/cmake-next/proposed/RepositoryInfo.txt.in
+++ b/cmake-next/proposed/RepositoryInfo.txt.in
@@ -1,0 +1,3 @@
+repository='@repository@'
+module='@module@'
+tag='@tag@'

--- a/cmake-next/proposed/RepositoryInfo.txt.in
+++ b/cmake-next/proposed/RepositoryInfo.txt.in
@@ -1,3 +1,0 @@
-repository='@repository@'
-module='@module@'
-tag='@tag@'

--- a/help/release/0.13.1.rst
+++ b/help/release/0.13.1.rst
@@ -1,4 +1,4 @@
-YCM 0.13.1 (UNRELEASED) Release Notes
+YCM 0.13.1 (2022-03-31) Release Notes
 *************************************
 
 .. only:: html
@@ -6,3 +6,11 @@ YCM 0.13.1 (UNRELEASED) Release Notes
   .. contents::
 
 Changes made since YCM 0.13.0 include the following.
+
+Important Changes
+=================
+
+* The ``ExternalProject`` module vendored in YCM (used in ``YCMBootstrap``) 
+  has been updated for compatibility with CMake 3.23 .
+
+* FindGraphviz: Fix finding graphviz not installed in system directories .

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -75,7 +75,7 @@ set(__YCMEPHELPER_INCLUDED TRUE)
 
 # Files downloaded during YCM bootstrap
 set(_ycm_CMakeParseArguments_sha1sum 0c4d3f7ed248145cbeb67cbd6fd7190baf2e4517)
-set(_ycm_ExternalProject_sha1sum     33dbf88a90f0774456ee9b303fe50fb587106892)
+set(_ycm_ExternalProject_sha1sum     ba8c547caa118c5ace50857c7839f76914926ef7)
 
 # Files in all projects that need to bootstrap YCM
 set(_ycm_IncludeUrl_sha1sum          997de3554f0d03ae22952a64fe26cdad118e8199)

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -75,7 +75,7 @@ set(__YCMEPHELPER_INCLUDED TRUE)
 
 # Files downloaded during YCM bootstrap
 set(_ycm_CMakeParseArguments_sha1sum 0c4d3f7ed248145cbeb67cbd6fd7190baf2e4517)
-set(_ycm_ExternalProject_sha1sum     c9d1167ae7730e9e6b1d9e9243a1f4f9bd9e2c5d)
+set(_ycm_ExternalProject_sha1sum     33dbf88a90f0774456ee9b303fe50fb587106892)
 
 # Files in all projects that need to bootstrap YCM
 set(_ycm_IncludeUrl_sha1sum          997de3554f0d03ae22952a64fe26cdad118e8199)


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1074 .

CI is currently not working on this repo, so this branch will be tested in https://github.com/robotology/robotology-superbuild/pull/1075 .

We also release YCM 0.13.1 with this change, to ensure that we have a version compatible with CMake 3.23 .