### PR TITLE
Switch changelog format to single CHANGELOG.md in the root directory of the repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [Unreleased]
+
+### Changed
+* Releases after 0.13.2 document their changes in a `CHANGELOG.md` file in the root of the repo.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
-* Releases after 0.13.2 document their changes in a `CHANGELOG.md` file in the root of the repo.
+* Releases after 0.13.2 document their changes in a `CHANGELOG.md` file in the root of the repo (https://github.com/robotology/ycm/pull/397).

--- a/help/release/0.13.2.rst
+++ b/help/release/0.13.2.rst
@@ -1,0 +1,13 @@
+YCM 0.13.2 (YYYY-MM-DD) Release Notes
+*************************************
+
+.. only:: html
+
+  .. contents::
+
+Changes made since YCM 0.13.1 include the following.
+
+Important Changes
+=================
+
+* For releases after YCM 0.13.2, the changelog is now mantained in the `CHANGELOG.md` file in the root of the source code.


### PR DESCRIPTION
It may be necessary to quickly release patch releases of YCM if there are environment regression due to new CMake releases, see for example https://github.com/robotology/ycm/pull/393 . 

However, at the moment the release process is a bit cumbersome as it is necessary to modify and even create several files as part of the release process. To streamline this, I think it is convenient to switch to a single file CHANGELOG.md file.