### PR TITLE
 FindOrBuildPackage: Do not run find_package if YCM_DISABLE_SYSTEM_PACKAGES is ON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * CMake 3.16 or later is now required (https://github.com/robotology/ycm/pull/386).
 * The `CMakeRC` module is imported again from the official repository, and it no longer prints the debug message (https://github.com/robotology/ycm/pull/384).
 * Avoid to download files from online repositories as part of the build process (https://github.com/robotology/ycm/pull/402).
+* FindOrBuildPackage: Do not call find_package if YCM_DISABLE_SYSTEM_PACKAGES is ON (). This change speeds up the CMake configuration time for superbuild that have many packages and `YCM_DISABLE_SYSTEM_PACKAGES` set to `ON`.
 
 ### Removed
 * Removed `FindEigen3.cmake` module (https://github.com/robotology/ycm/pull/399).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * CMake 3.16 or later is now required (https://github.com/robotology/ycm/pull/386).
 * The `CMakeRC` module is imported again from the official repository, and it no longer prints the debug message (https://github.com/robotology/ycm/pull/384).
 * Avoid to download files from online repositories as part of the build process (https://github.com/robotology/ycm/pull/402).
-* FindOrBuildPackage: Do not call find_package if YCM_DISABLE_SYSTEM_PACKAGES is ON (). This change speeds up the CMake configuration time for superbuild that have many packages and `YCM_DISABLE_SYSTEM_PACKAGES` set to `ON`.
+* FindOrBuildPackage: Do not call find_package if YCM_DISABLE_SYSTEM_PACKAGES is ON (https://github.com/robotology/ycm/pull/404). This change speeds up the CMake configuration time for superbuild that have many packages and `YCM_DISABLE_SYSTEM_PACKAGES` set to `ON`.
 
 ### Removed
 * Removed `FindEigen3.cmake` module (https://github.com/robotology/ycm/pull/399).

--- a/modules/FindOrBuildPackage.cmake
+++ b/modules/FindOrBuildPackage.cmake
@@ -134,16 +134,19 @@ function(FIND_OR_BUILD_PACKAGE _pkg)
         set(_findArgs ${_${_PKG}_UNPARSED_ARGUMENTS})
     endif()
 
+    option(YCM_DISABLE_SYSTEM_PACKAGES "Disable use of all the system installed packages" OFF)
+    mark_as_advanced(YCM_DISABLE_SYSTEM_PACKAGES)
+
 # Preliminary find_package to enable/disable USE_SYSTEM_${_PKG} option
     # Use the FindPkg.cmake module first
-    if(NOT _${_PKG}_NO_MODULE AND NOT _${_PKG}_CONFIG)
+    if(NOT _${_PKG}_NO_MODULE AND NOT _${_PKG}_CONFIG AND NOT YCM_DISABLE_SYSTEM_PACKAGES)
         # FIXME This might require to check for all the other arguments, or they
         #       might conflict with the MODULE argument
         find_package(${_pkg} ${_version} ${_findArgs} MODULE QUIET)
     endif()
 
     # If the module failed, search a PkgConfig.cmake file
-    if(NOT ${_pkg}_FOUND AND NOT ${_PKG}_FOUND AND NOT _${_PKG}_MODULE)
+    if(NOT ${_pkg}_FOUND AND NOT ${_PKG}_FOUND AND NOT _${_PKG}_MODULE AND NOT YCM_DISABLE_SYSTEM_PACKAGES)
         find_package(${_pkg} ${_version} ${_findArgs} CONFIG QUIET)
     endif()
 
@@ -154,8 +157,6 @@ function(FIND_OR_BUILD_PACKAGE _pkg)
         list(REMOVE_DUPLICATES _ycm_projects)
         set_property(GLOBAL PROPERTY YCM_PROJECTS ${_ycm_projects})
     endif()
-    option(YCM_DISABLE_SYSTEM_PACKAGES "Disable use of all the system installed packages" OFF)
-    mark_as_advanced(YCM_DISABLE_SYSTEM_PACKAGES)
     cmake_dependent_option(USE_SYSTEM_${_PKG} "Use system installed ${_pkg}" ON "HAVE_SYSTEM_${_PKG};NOT YCM_DISABLE_SYSTEM_PACKAGES" OFF)
     mark_as_advanced(USE_SYSTEM_${_PKG})
 


### PR DESCRIPTION
In FindOrBuildPackage a preliminary `find_package` is run to decide if it make sense to provide to the 
user the `USE_SYSTEM_${_PKG}` option. However if `YCM_DISABLE_SYSTEM_PACKAGES`  is ON, the
`USE_SYSTEM_${_PKG}` option is already disabled, so we can skip the `find_package` calls.

This change should dramatically reduce the CMake configuration for superbuilds in which `YCM_DISABLE_SYSTEM_PACKAGES`  is ON and that have many subpackages.