### PR TITLE
Add FinduSockets.cmake and FinduWebSockets.cmake find-modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased Minor]
 
+### Added
+
+* Added `FinduSockets` and `FinduWebSockets` find modules  (https://github.com/robotology/ycm/pull/421). 
+
 ## [Unreleased Patch]
 
 ## [0.14.2] - 2022-06-10

--- a/find-modules/CMakeLists.txt
+++ b/find-modules/CMakeLists.txt
@@ -38,6 +38,8 @@ set(YCM_FIND_MODULES FindACE.cmake
                      FindSQLite.cmake
                      FindStage.cmake
                      FindTinyXML.cmake
+                     FinduSockets.cmake
+                     FinduWebSockets.cmake
                      FindYamlCpp.cmake
                      FindZFP.cmake)
 

--- a/find-modules/FinduSockets.cmake
+++ b/find-modules/FinduSockets.cmake
@@ -25,7 +25,7 @@ if(uSockets_FOUND)
       add_library(uSockets::uSockets UNKNOWN IMPORTED)
       set_target_properties(uSockets::uSockets PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${uSockets_INCLUDE_DIR}")
-      set_property(TARGET uSockets::uSockets APPEND PROPERTY
+      set_property(TARGET uSockets::uSockets PROPERTY
         IMPORTED_LOCATION "${uSockets_LIBRARY}")
     endif()
 endif()

--- a/find-modules/FinduSockets.cmake
+++ b/find-modules/FinduSockets.cmake
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: 2023 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+#[=======================================================================[.rst:
+FinduSockets
+-----------
+
+The following imported targets are created:
+
+uSockets::uSockets
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+find_path(uSockets_INCLUDE_DIR libusockets.h)
+mark_as_advanced(uSockets_INCLUDE_DIR)
+find_library(uSockets_LIBRARY uSockets libuSockets)
+mark_as_advanced(uSockets_LIBRARY)
+
+find_package_handle_standard_args(uSockets DEFAULT_MSG uSockets_INCLUDE_DIR uSockets_LIBRARY)
+
+if(uSockets_FOUND)
+    if(NOT TARGET uSockets::uSockets)
+      add_library(uSockets::uSockets UNKNOWN IMPORTED)
+      set_target_properties(uSockets::uSockets PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${uSockets_INCLUDE_DIR}")
+      set_property(TARGET uSockets::uSockets APPEND PROPERTY
+        IMPORTED_LOCATION "${uSockets_LIBRARY}")
+    endif()
+endif()

--- a/find-modules/FinduWebSockets.cmake
+++ b/find-modules/FinduWebSockets.cmake
@@ -14,6 +14,9 @@ uWebSockets::uWebSockets
 #]=======================================================================]
 
 include(FindPackageHandleStandardArgs)
+include(CMakeFindDependencyMacro)
+
+find_dependency(ZLIB REQUIRED)
 
 find_path(uWebSockets_INCLUDE_DIR WebSocket.h PATH_SUFFIXES uwebsockets uWebSockets)
 mark_as_advanced(uWebSockets_INCLUDE_DIR)
@@ -25,5 +28,7 @@ if(uWebSockets_FOUND)
       add_library(uWebSockets::uWebSockets INTERFACE IMPORTED)
       set_target_properties(uWebSockets::uWebSockets PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${uWebSockets_INCLUDE_DIR}")
+      set_target_properties(uWebSockets::uWebSockets PROPERTIES 
+        INTERFACE_LINK_LIBRARIES ZLIB::ZLIB)  
     endif()
 endif()

--- a/find-modules/FinduWebSockets.cmake
+++ b/find-modules/FinduWebSockets.cmake
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2023 Istituto Italiano di Tecnologia (IIT)
+# SPDX-License-Identifier: BSD-3-Clause
+
+#[=======================================================================[.rst:
+FinduWebSockets
+-----------
+
+Find the uWebSockets library.
+
+The following imported targets are created:
+
+uWebSockets::uWebSockets
+
+#]=======================================================================]
+
+include(FindPackageHandleStandardArgs)
+
+find_path(uWebSockets_INCLUDE_DIR WebSocket.h PATH_SUFFIXES uwebsockets uWebSockets)
+mark_as_advanced(uWebSockets_INCLUDE_DIR)
+
+find_package_handle_standard_args(uWebSockets DEFAULT_MSG uWebSockets_INCLUDE_DIR)
+
+if(uWebSockets_FOUND)
+    if(NOT TARGET uWebSockets::uWebSockets)
+      add_library(uWebSockets::uWebSockets INTERFACE IMPORTED)
+      set_target_properties(uWebSockets::uWebSockets PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${uWebSockets_INCLUDE_DIR}")
+    endif()
+endif()

--- a/find-modules/FinduWebSockets.cmake
+++ b/find-modules/FinduWebSockets.cmake
@@ -19,7 +19,11 @@ include(CMakeFindDependencyMacro)
 find_dependency(uSockets REQUIRED)
 find_dependency(ZLIB REQUIRED)
 
-find_path(uWebSockets_INCLUDE_DIR WebSocket.h PATH_SUFFIXES uwebsockets uWebSockets)
+# We do not use WebSocket.h as it has the same name of a
+# Windows system header, found for example in
+# C:/Program Files (x86)/Windows Kits/10/Include/10.0.19041.0/um
+find_path(uWebSockets_INCLUDE_DIR WebSocketProtocol.h PATH_SUFFIXES uWebSockets uwebsockets)
+
 mark_as_advanced(uWebSockets_INCLUDE_DIR)
 
 find_package_handle_standard_args(uWebSockets DEFAULT_MSG uWebSockets_INCLUDE_DIR)

--- a/find-modules/FinduWebSockets.cmake
+++ b/find-modules/FinduWebSockets.cmake
@@ -16,6 +16,7 @@ uWebSockets::uWebSockets
 include(FindPackageHandleStandardArgs)
 include(CMakeFindDependencyMacro)
 
+find_dependency(uSockets REQUIRED)
 find_dependency(ZLIB REQUIRED)
 
 find_path(uWebSockets_INCLUDE_DIR WebSocket.h PATH_SUFFIXES uwebsockets uWebSockets)
@@ -29,6 +30,8 @@ if(uWebSockets_FOUND)
       set_target_properties(uWebSockets::uWebSockets PROPERTIES
         INTERFACE_INCLUDE_DIRECTORIES "${uWebSockets_INCLUDE_DIR}")
       set_target_properties(uWebSockets::uWebSockets PROPERTIES 
-        INTERFACE_LINK_LIBRARIES ZLIB::ZLIB)  
+        INTERFACE_LINK_LIBRARIES ZLIB::ZLIB)
+      set_property(TARGET uWebSockets::uWebSockets APPEND PROPERTY
+        INTERFACE_LINK_LIBRARIES uSockets::uSockets)
     endif()
 endif()


### PR DESCRIPTION
Add CMake modules to find the [`uSockets`](https://github.com/uNetworking/uSockets) and [`uWebSockets`](https://github.com/uNetworking/uWebSockets) libraries.

They are supposed to be used as:
~~~cmake
find_package(uSockets REQUIRED)

target_link_libraries(<..> PRIVATE uSockets::uSockets)
~~~

and 

~~~cmake
find_package(uWebSockets REQUIRED)

target_link_libraries(<..> PRIVATE uWebSockets::uWebSockets)
~~~