### PR TITLE
YCMEPHelper: If CMAKE_EXPORT_COMPILE_COMMANDS is defined and ON, pass it to all subprojects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased Patch]
 
+### Changed
+
+* YCMEPHelper: If CMAKE_EXPORT_COMPILE_COMMANDS is defined and ON, pass it to all subprojects (https://github.com/robotology/ycm/pull/442).
+
 ### Deprecated
 
 * FindGLFW3: Use glfw3Config.cmake and mark module as deprecated. Instead of using `find_package(GLFW3)`, please use `find_package(glfw3 NO_MODULE)` and link the `glfw` imported target (https://github.com/robotology/ycm/pull/441).

--- a/modules/YCMEPHelper.cmake
+++ b/modules/YCMEPHelper.cmake
@@ -255,6 +255,12 @@ macro(_YCM_SETUP)
                          "-DCMAKE_PREFIX_PATH:PATH=${_CMAKE_PREFIX_PATH}") # Path used by cmake for finding stuff
   list(APPEND _YCM_EP_CMAKE_ARGS ${_YCM_EP_ADDITIONAL_CMAKE_ARGS})
 
+  # If CMAKE_EXPORT_COMPILE_COMMANDS is defined, pass it along to the sub-projects
+  # See https://github.com/robotology/robotology-superbuild/issues/1596
+  if(DEFINED CMAKE_EXPORT_COMPILE_COMMANDS AND ${CMAKE_EXPORT_COMPILE_COMMANDS})
+    list(APPEND _YCM_EP_CMAKE_ARGS "-DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=${CMAKE_EXPORT_COMPILE_COMMANDS}")
+  endif()
+
   # Default CMAKE_CACHE_ARGS (Initial cache, forced)
   set(_YCM_EP_CMAKE_CACHE_ARGS "-DCMAKE_INSTALL_PREFIX:PATH=${YCM_EP_INSTALL_DIR}") # Where to do the installation
 


### PR DESCRIPTION
Fix part of https://github.com/robotology/robotology-superbuild/issues/1596 . As discussed in https://github.com/robotology/robotology-superbuild/issues/1596 one could use the `CMAKE_EXPORT_COMPILE_COMMANDS` environment variable, but this has the downside that is considered only if the build is created from zero, and it has no effects on existing builds.